### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/TranslucentTB/main.cpp
+++ b/TranslucentTB/main.cpp
@@ -973,7 +973,7 @@ bool singleProc()
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPreInst, LPSTR pCmdLine, int nCmdShow)
 {
 	HRESULT dpi_success = SetProcessDpiAwareness(PROCESS_SYSTEM_DPI_AWARE);
-	if (!dpi_success) { OutputDebugStringW(L"Per-monitor DPI scaling failed"); }
+	if (FAILED(dpi_success)) { OutputDebugStringW(L"Per-monitor DPI scaling failed"); return 1; }
 
 	ParseCmdOptions(true); // Command line argument settings, config file only
 	ParseConfigFile(L"config.cfg"); // Config file settings
@@ -1012,7 +1012,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPreInst, LPSTR pCmdLine, int 
 	//Virtual Desktop stuff
 	::CoInitialize(NULL);
 	HRESULT desktop_success = ::CoCreateInstance(__uuidof(VirtualDesktopManager), NULL, CLSCTX_INPROC_SERVER, IID_IVirtualDesktopManager, (void **)&desktop_manager);
-	if (!desktop_success) { OutputDebugStringW(L"Initialization of VirtualDesktopManager failed"); }
+	if (FAILED(desktop_success)) { OutputDebugStringW(L"Initialization of VirtualDesktopManager failed"); return 1; }
 
 	RefreshHandles();
 	if (opt.dynamicws)


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. 

Your application has minimum supported OS is Windows 10, because of IVirtualDesktopManager interface usage.
You obtain this interface and has wrong check of result. This result is not boolean, therefore you doesn't get output error string even if you run this app not under Win10.
And there is no exit from app if you don't get success result of obtaining of interface.
You should apply it and your app will not crashes under other versions of Windows OS.

[V545](https://www.viva64.com/en/w/v545/) Such conditional expression of 'if' statement is incorrect for the HRESULT type value 'dpi_success'. The SUCCEEDED or FAILED macro should be used instead. main.cpp 976
[V545](https://www.viva64.com/en/w/v545/) Such conditional expression of 'if' statement is incorrect for the HRESULT type value 'desktop_success'. The SUCCEEDED or FAILED macro should be used instead. main.cpp 1015