### PR TITLE
Fix not work on primary monitor after monitor change

### DIFF
--- a/TranslucentTB/ttblog.cpp
+++ b/TranslucentTB/ttblog.cpp
@@ -10,6 +10,7 @@
 #ifndef STORE
 #include <vector>
 #endif
+#include <iomanip>
 #include <WinBase.h>
 #include <winerror.h>
 #include <winnt.h>
@@ -154,12 +155,19 @@ void Log::OutputMessage(const std::wstring &message)
 
 	if (*m_FileHandle)
 	{
-		std::time_t current_time = std::time(0);
-
+		SYSTEMTIME t = SYSTEMTIME();
+		GetLocalTime(&t);
+		
 		std::wostringstream buffer;
-		buffer << L'(' << _wctime(&current_time);
-		buffer.seekp(-1, std::ios_base::end); // Seek behind the newline created by _wctime
-		buffer << L") " << message << L"\r\n";
+		buffer << L'(' << std::setfill(L'0')
+			<< std::setw(4) << t.wYear << L'-'
+			<< std::setw(2) << t.wMonth << L'-'
+			<< std::setw(2) << t.wDay << L' '
+			<< std::setw(2) << t.wHour << L':'
+			<< std::setw(2) << t.wMinute << L':'
+			<< std::setw(2) << t.wSecond << L'.'
+			<< std::setw(3) << t.wMilliseconds
+			<< L") " << message << L"\r\n";
 
 		const std::wstring error = buffer.str();
 


### PR DESCRIPTION
Basic idea is simple, as manual trigger refresh taskbar handler works, I let program wait for a while before doing refresh.

I tested some monitors I can find, the time need to be wait before refresh can take effect keeps same on one monitor but varies on different monitors. Wait time on connection is 80 ~ 250ms, and on disconnection is 10 ~ 30ms.

I picked 400ms for connection wait and 40ms for disconnection. I'm not sure if it's long enough everywhere, but taskbar will show in normal appearance during waiting so wait time can't be set too long. There may need more test to find a good time choice, or make it configurable to users.

The taskbar can flicker quite a few times after monitor change. I found each time monitor connect/disconnect, both WM_DISPLAYCHANGE and EVENT_OBJECT_CREATE(DESTROY) callback will be called and taskbar handles will unnecessarily be refreshed twice. I'm not sure if in some case only one callback will be called so I just ignore a refresh if another refresh is waiting or working. The 40ms wait time on WM_DISPLAYCHANGE callback is to prevent one refresh called just after another refresh is done.

Log time format is changed to include millisecond for debug.