### PR TITLE
Add Japanese translation

### DIFF
--- a/AppPackage/AppPackage.wapproj
+++ b/AppPackage/AppPackage.wapproj
@@ -71,6 +71,7 @@
     <Content Include="Assets\Wide310x150Logo.scale-200.jpeg" />
     <Content Include="Assets\Wide310x150Logo.scale-400.jpeg" />
     <PRIResource Include="Strings\en-US\Resources.resw" />
+    <PRIResource Include="Strings\ja-JP\Resources.resw" />
     <PRIResource Include="Strings\zh-CN\Resources.resw" />
     <PRIResource Include="Strings\zh-TW\Resources.resw" />
   </ItemGroup>

--- a/AppPackage/Strings/ja-JP/Resources.resw
+++ b/AppPackage/Strings/ja-JP/Resources.resw
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AppDescription" xml:space="preserve">
+    <value>Windows のタスクバーを透明/半透明にする軽快なソフトウェア</value>
+  </data>
+  <data name="PublisherDisplayName" xml:space="preserve">
+    <value>TranslucentTB オープンソースの開発者</value>
+  </data>
+</root>

--- a/TranslucentTB/TranslucentTB.vcxproj
+++ b/TranslucentTB/TranslucentTB.vcxproj
@@ -104,6 +104,7 @@
   <ItemGroup>
     <ResourceCompile Include="resources\TranslucentTB.rc2" />
     <ResourceCompile Include="resources\language\TranslucentTB.en-US.rc2" />
+    <ResourceCompile Include="resources\language\TranslucentTB.ja-JP.rc2" />
     <ResourceCompile Include="resources\language\TranslucentTB.zh-CN.rc2" />
     <ResourceCompile Include="resources\language\TranslucentTB.zh-TW.rc2" />
   </ItemGroup>

--- a/TranslucentTB/TranslucentTB.vcxproj.filters
+++ b/TranslucentTB/TranslucentTB.vcxproj.filters
@@ -165,6 +165,9 @@
     <ResourceCompile Include="resources\language\TranslucentTB.en-US.rc2">
       <Filter>Resource Files</Filter>
     </ResourceCompile>
+    <ResourceCompile Include="resources\language\TranslucentTB.ja-JP.rc2">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
     <ResourceCompile Include="resources\language\TranslucentTB.zh-TW.rc2">
       <Filter>Resource Files</Filter>
     </ResourceCompile>

--- a/TranslucentTB/resources/language/TranslucentTB.ja-JP.rc2
+++ b/TranslucentTB/resources/language/TranslucentTB.ja-JP.rc2
@@ -1,0 +1,62 @@
+#pragma code_page(65001)
+
+#ifdef APSTUDIO_INVOKED
+#error Please edit this file manually.
+#endif
+
+#include <ddeml.h>
+#include <winres.h>
+#include "../../../Common/appinfo.hpp"
+#include "../ids.h"
+
+LANGUAGE LANG_JAPANESE, SUBLANG_NEUTRAL
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Version
+//
+
+VS_VERSION_INFO VERSIONINFO
+	FILEVERSION APP_VERSION_FIXED
+	PRODUCTVERSION APP_VERSION_FIXED
+	FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
+#ifdef _DEBUG
+	FILEFLAGS VS_FF_DEBUG
+#endif
+	FILEOS VOS_NT_WINDOWS32
+	FILETYPE VFT_APP
+{
+	BLOCK L"StringFileInfo"
+	{
+		BLOCK L"041104b0"
+		{
+			VALUE L"FileDescription", APP_NAME
+			VALUE L"FileVersion", APP_VERSION
+			VALUE L"InternalName", APP_NAME L".exe"
+			VALUE L"OriginalFilename", APP_NAME L".exe"
+			VALUE L"ProductName", APP_NAME
+			VALUE L"ProductVersion", APP_VERSION
+			VALUE L"Comments", L"Windows のタスクバーを透明/半透明にする軽快なソフトウェア。"
+			VALUE L"CompanyName", APP_NAME L" オープンソースの開発者"
+			VALUE L"LegalCopyright", L"Copyright © " APP_COPYRIGHT_YEAR L" " APP_NAME L" オープンソースの開発者"
+		}
+	}
+	BLOCK L"VarFileInfo"
+	{
+		VALUE L"Translation", 0x0411, CP_WINUNICODE
+	}
+}
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Strings
+//
+
+STRINGTABLE
+{
+	IDS_WELCOME_NOTIFICATION APP_NAME L" はシステムトレイに格納されています。\n\nトレイのアイコンを右クリックすると設定の変更、起動時にアプリを実行する設定、情報の表示などが行えます。"
+	IDS_HIDETRAY_DIALOG L"この変更は一時的です。次回 " APP_NAME L" を開始すると元に戻ります。\n\n持続的な変更にするには、「高度」 > 「設定の編集」にて設定ファイルを編集し、hide_tray を false に設定します。\n\n続けますか?"
+	IDS_ALREADY_RUNNING APP_NAME L" は既に実行中です! トレイのアイコンを右クリックして利用できます。"
+}

--- a/TranslucentTB/resources/language/TranslucentTB.ja-JP.rc2
+++ b/TranslucentTB/resources/language/TranslucentTB.ja-JP.rc2
@@ -9,7 +9,7 @@
 #include "../../../Common/appinfo.hpp"
 #include "../ids.h"
 
-LANGUAGE LANG_JAPANESE, SUBLANG_NEUTRAL
+LANGUAGE LANG_JAPANESE, SUBLANG_JAPANESE_JAPAN
 
 
 /////////////////////////////////////////////////////////////////////////////

--- a/Xaml/Strings/ja-JP/Resources.resw
+++ b/Xaml/Strings/ja-JP/Resources.resw
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ColorPickerPage_AlwaysOnTop.Text" xml:space="preserve">
+    <value>常に手前に表示</value>
+  </data>
+  <data name="ColorPickerPage_ConfirmCloseDialog.CloseButtonText" xml:space="preserve">
+    <value>キャンセル</value>
+  </data>
+  <data name="ColorPickerPage_ConfirmCloseDialog.Content" xml:space="preserve">
+    <value>色の変更を保存しますか?</value>
+  </data>
+  <data name="ColorPickerPage_ConfirmCloseDialog.PrimaryButtonText" xml:space="preserve">
+    <value>はい</value>
+  </data>
+  <data name="ColorPickerPage_ConfirmCloseDialog.SecondaryButtonText" xml:space="preserve">
+    <value>いいえ</value>
+  </data>
+  <data name="FramelessPage_Close.Text" xml:space="preserve">
+    <value>閉じる</value>
+  </data>
+  <data name="TrayFlyoutPage_About.Text" xml:space="preserve">
+    <value>TranslucentTB について</value>
+  </data>
+  <data name="TrayFlyoutPage_AccentColor.Text" xml:space="preserve">
+    <value>アクセントカラー</value>
+  </data>
+  <data name="TrayFlyoutPage_Acrylic.Text" xml:space="preserve">
+    <value>アクリル</value>
+  </data>
+  <data name="TrayFlyoutPage_Advanced.Text" xml:space="preserve">
+    <value>高度</value>
+  </data>
+  <data name="TrayFlyoutPage_Advanced_CompactThunkHeap.Text" xml:space="preserve">
+    <value>サンクのヒープを圧縮</value>
+  </data>
+  <data name="TrayFlyoutPage_Advanced_DisableHotSettings.Text" xml:space="preserve">
+    <value>設定を保存しない</value>
+  </data>
+  <data name="TrayFlyoutPage_Advanced_DumpDynamicState.Text" xml:space="preserve">
+    <value>ログに動的状態のダンプ出力</value>
+  </data>
+  <data name="TrayFlyoutPage_Advanced_EditSettings.Text" xml:space="preserve">
+    <value>設定の編集</value>
+  </data>
+  <data name="TrayFlyoutPage_Advanced_HideTrayIcon.Text" xml:space="preserve">
+    <value>トレイアイコンを非表示</value>
+  </data>
+  <data name="TrayFlyoutPage_Advanced_LogVerbosity.Text" xml:space="preserve">
+    <value>ログの記録対象</value>
+  </data>
+  <data name="TrayFlyoutPage_Advanced_LogVerbosity_Critical.Text" xml:space="preserve">
+    <value>重大</value>
+  </data>
+  <data name="TrayFlyoutPage_Advanced_LogVerbosity_Debug.Text" xml:space="preserve">
+    <value>デバッグ</value>
+  </data>
+  <data name="TrayFlyoutPage_Advanced_LogVerbosity_Error.Text" xml:space="preserve">
+    <value>エラー</value>
+  </data>
+  <data name="TrayFlyoutPage_Advanced_LogVerbosity_Information.Text" xml:space="preserve">
+    <value>情報</value>
+  </data>
+  <data name="TrayFlyoutPage_Advanced_LogVerbosity_Off.Text" xml:space="preserve">
+    <value>オフ</value>
+  </data>
+  <data name="TrayFlyoutPage_Advanced_LogVerbosity_Trace.Text" xml:space="preserve">
+    <value>細かく追跡</value>
+  </data>
+  <data name="TrayFlyoutPage_Advanced_LogVerbosity_Warning.Text" xml:space="preserve">
+    <value>警告</value>
+  </data>
+  <data name="TrayFlyoutPage_Advanced_OpenLogFile.Text" xml:space="preserve">
+    <value>ログファイルを開く</value>
+  </data>
+  <data name="TrayFlyoutPage_Advanced_ResetDynamicState.Text" xml:space="preserve">
+    <value>動的状態をリセット</value>
+  </data>
+  <data name="TrayFlyoutPage_Advanced_ResetSettings.Text" xml:space="preserve">
+    <value>初期設定に戻す</value>
+  </data>
+  <data name="TrayFlyoutPage_BatterySaver.Text" xml:space="preserve">
+    <value>バッテリー節約機能</value>
+  </data>
+  <data name="TrayFlyoutPage_Blur.Text" xml:space="preserve">
+    <value>ぼかし</value>
+  </data>
+  <data name="TrayFlyoutPage_Clear.Text" xml:space="preserve">
+    <value>透明</value>
+  </data>
+  <data name="TrayFlyoutPage_Desktop.Text" xml:space="preserve">
+    <value>デスクトップ</value>
+  </data>
+  <data name="TrayFlyoutPage_Enabled.Text" xml:space="preserve">
+    <value>有効</value>
+  </data>
+  <data name="TrayFlyoutPage_Exit.Text" xml:space="preserve">
+    <value>終了</value>
+  </data>
+  <data name="TrayFlyoutPage_MaximizedWindow.Text" xml:space="preserve">
+    <value>ウィンドウ最大化</value>
+  </data>
+  <data name="TrayFlyoutPage_Normal.Text" xml:space="preserve">
+    <value>通常</value>
+  </data>
+  <data name="TrayFlyoutPage_Opaque.Text" xml:space="preserve">
+    <value>不透明</value>
+  </data>
+  <data name="TrayFlyoutPage_OpenAtBoot.Text" xml:space="preserve">
+    <value>起動時に実行</value>
+  </data>
+  <data name="TrayFlyoutPage_PeekButton.Text" xml:space="preserve">
+    <value>デスクトップ Peek ピークボタンを表示</value>
+  </data>
+  <data name="TrayFlyoutPage_SearchOpened.Text" xml:space="preserve">
+    <value>検索の展開</value>
+  </data>
+  <data name="TrayFlyoutPage_StartOpened.Text" xml:space="preserve">
+    <value>スタートメニュー展開</value>
+  </data>
+  <data name="TrayFlyoutPage_TaskViewOpened.Text" xml:space="preserve">
+    <value>タスクビュー展開</value>
+  </data>
+  <data name="TrayFlyoutPage_TipsAndTricks.Text" xml:space="preserve">
+    <value>使い方のコツ</value>
+  </data>
+  <data name="TrayFlyoutPage_VisibleWindow.Text" xml:space="preserve">
+    <value>ウィンドウ表示</value>
+  </data>
+  <data name="WelcomePage.Title" xml:space="preserve">
+    <value>TranslucentTB へようこそ!</value>
+  </data>
+  <data name="WelcomePage_Action_Configure.Description" xml:space="preserve">
+    <value>トレイアイコンを右クリックし、「高度」 &gt; 「設定の編集」を選択することで、いつでも行えます。ファイルを保存すると、変更点が自動的に読み込まれます。</value>
+    <comment>Mind the newline (a.k.a. enter)</comment>
+  </data>
+  <data name="WelcomePage_Action_Configure.Name" xml:space="preserve">
+    <value>設定ファイルの編集</value>
+  </data>
+  <data name="WelcomePage_Action_Discord.Description" xml:space="preserve">
+    <value>開発者とチャットしたり、本プログラムの使い方を手助けをしてもらいましょう。</value>
+  </data>
+  <data name="WelcomePage_Action_Discord.Name" xml:space="preserve">
+    <value>私たちの Discord</value>
+  </data>
+  <data name="WelcomePage_Action_Donate.Description" xml:space="preserve">
+    <value>寄付によって私たちへの支援を表明できます。一度だけでも可能ですし定期的な寄付も行えます❤</value>
+  </data>
+  <data name="WelcomePage_Action_Donate.Name" xml:space="preserve">
+    <value>Liberapay でプロジェクトに寄付</value>
+  </data>
+  <data name="WelcomePage_ButtonBar_Continue.Content" xml:space="preserve">
+    <value>続行</value>
+  </data>
+  <data name="WelcomePage_ButtonBar_Exit.Content" xml:space="preserve">
+    <value>終了</value>
+  </data>
+  <data name="WelcomePage_Message_Hyperlink.Text" xml:space="preserve">
+    <value>GitHub 上で issue を作成し</value>
+  </data>
+  <data name="WelcomePage_Message_Prefix.Text" xml:space="preserve">
+    <value>TranslucentTB をご利用いただき感謝します! 「続行」すると、タスクバーをあなた好みの見た目に設定できます。ぜひお試しください。</value>
+  </data>
+  <data name="WelcomePage_Message_Suffix.Text" xml:space="preserve">
+    <value>問題を報告したり、機能を要望することもできます!</value>
+  </data>
+</root>

--- a/Xaml/Xaml.vcxproj
+++ b/Xaml/Xaml.vcxproj
@@ -404,6 +404,7 @@
   </ItemGroup>
   <ItemGroup>
     <PRIResource Include="Strings\en-US\Resources.resw" />
+    <PRIResource Include="Strings\ja-JP\Resources.resw" />
     <PRIResource Include="Strings\zh-CN\Resources.resw" />
     <PRIResource Include="Strings\zh-TW\Resources.resw" />
   </ItemGroup>

--- a/Xaml/Xaml.vcxproj.filters
+++ b/Xaml/Xaml.vcxproj.filters
@@ -15,6 +15,7 @@
       <UniqueIdentifier>{7b45cdc2-9ecd-4045-84b1-9ffd61a63be8}</UniqueIdentifier>
     </Filter>
     <Filter Include="Resources\Strings\ja-JP">
+      <UniqueIdentifier>{aa4e1600-db10-4d3f-9199-e663c3ed832d}</UniqueIdentifier>
     </Filter>
     <Filter Include="Resources\Strings\zh-TW">
       <UniqueIdentifier>{d5edc189-37f7-456e-a1a2-277be644f570}</UniqueIdentifier>
@@ -96,7 +97,7 @@
       <Filter>Resources\Strings\en-US</Filter>
     </PRIResource>
     <PRIResource Include="Strings\ja-JP\Resources.resw">
-      <Filter>Resources\Strings\zh-CN</Filter>
+      <Filter>Resources\Strings\ja-JP</Filter>
     </PRIResource>
     <PRIResource Include="Strings\zh-TW\Resources.resw">
       <Filter>Resources\Strings\zh-TW</Filter>

--- a/Xaml/Xaml.vcxproj.filters
+++ b/Xaml/Xaml.vcxproj.filters
@@ -14,6 +14,8 @@
     <Filter Include="Resources\Strings\en-US">
       <UniqueIdentifier>{7b45cdc2-9ecd-4045-84b1-9ffd61a63be8}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Resources\Strings\ja-JP">
+    </Filter>
     <Filter Include="Resources\Strings\zh-TW">
       <UniqueIdentifier>{d5edc189-37f7-456e-a1a2-277be644f570}</UniqueIdentifier>
     </Filter>
@@ -92,6 +94,9 @@
   <ItemGroup>
     <PRIResource Include="Strings\en-US\Resources.resw">
       <Filter>Resources\Strings\en-US</Filter>
+    </PRIResource>
+    <PRIResource Include="Strings\ja-JP\Resources.resw">
+      <Filter>Resources\Strings\zh-CN</Filter>
     </PRIResource>
     <PRIResource Include="Strings\zh-TW\Resources.resw">
       <Filter>Resources\Strings\zh-TW</Filter>


### PR DESCRIPTION
I have translated a variety of software.

I Diffed the English and Chinese files; other than the ```UniqueIdentifier```, the changes are the same as in that Diff. I simply created it in a text editor. So, there is no ```UniqueIdentifier``` in ```Xaml.vcxproj.filters```.

> The UniqueIdentifier node is optional.
https://docs.microsoft.com/en-us/cpp/build/reference/vcxproj-filters-files?view=msvc-170

And, I have tried to compile, but I am not using Windows 11. I can't even try SDK build 22543. Visual Studio said you need SDK build 22543.

