### PR TITLE
feat(rules): add option to specify inactive window state

### DIFF
--- a/Common/Common.vcxitems
+++ b/Common/Common.vcxitems
@@ -16,6 +16,7 @@
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)appinfo.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)arch.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)config\activeinactivetaskbarappearance.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)config\ruledtaskbarappearance.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)simplefactory.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)undoc\explorer.hpp" />

--- a/Common/config/activeinactivetaskbarappearance.hpp
+++ b/Common/config/activeinactivetaskbarappearance.hpp
@@ -45,6 +45,7 @@ struct ActiveInactiveTaskbarAppearance : TaskbarAppearance {
 			}
 		}
 	}
+
 private:
 	static constexpr std::wstring_view INACTIVE_KEY = L"inactive";
 };

--- a/Common/config/activeinactivetaskbarappearance.hpp
+++ b/Common/config/activeinactivetaskbarappearance.hpp
@@ -16,7 +16,7 @@ struct ActiveInactiveTaskbarAppearance : TaskbarAppearance {
 	{ }
 
 	template<typename Writer>
-	inline void Serialize(Writer& writer) const
+	inline void Serialize(Writer &writer) const
 	{
 		TaskbarAppearance::Serialize(writer);
 		if (Inactive.has_value()) {
@@ -24,7 +24,7 @@ struct ActiveInactiveTaskbarAppearance : TaskbarAppearance {
 		}
 	}
 
-	inline void Deserialize(const rjh::value_t& obj, void (*unknownKeyCallback)(std::wstring_view))
+	inline void Deserialize(const rjh::value_t &obj, void (*unknownKeyCallback)(std::wstring_view))
 	{
 		rjh::EnsureType(rj::Type::kObjectType, obj.GetType(), L"root node");
 

--- a/Common/config/activeinactivetaskbarappearance.hpp
+++ b/Common/config/activeinactivetaskbarappearance.hpp
@@ -1,0 +1,50 @@
+#pragma once
+#include <string_view>
+#include <optional>
+
+
+#include "rapidjsonhelper.hpp"
+#include "taskbarappearance.hpp"
+
+struct ActiveInactiveTaskbarAppearance : TaskbarAppearance {
+	std::optional<TaskbarAppearance> Inactive;
+
+	ActiveInactiveTaskbarAppearance() = default;
+	ActiveInactiveTaskbarAppearance(std::optional<TaskbarAppearance> inactive, ACCENT_STATE accent, Util::Color color, bool showPeek, bool showLine) :
+		TaskbarAppearance(accent, color, showPeek, showLine),
+		Inactive(std::move(inactive))
+	{ }
+
+	template<typename Writer>
+	inline void Serialize(Writer& writer) const
+	{
+		TaskbarAppearance::Serialize(writer);
+		if (Inactive.has_value()) {
+			rjh::Serialize(writer, Inactive.value(), INACTIVE_KEY);
+		}
+	}
+
+	inline void Deserialize(const rjh::value_t& obj, void (*unknownKeyCallback)(std::wstring_view))
+	{
+		rjh::EnsureType(rj::Type::kObjectType, obj.GetType(), L"root node");
+
+		for (auto it = obj.MemberBegin(); it != obj.MemberEnd(); ++it)
+		{
+			rjh::EnsureType(rj::Type::kStringType, it->name.GetType(), L"member name");
+
+			const auto key = rjh::ValueToStringView(it->name);
+			if (key == INACTIVE_KEY)
+			{
+				TaskbarAppearance appearance;
+				rjh::Deserialize(it->value, appearance, key, unknownKeyCallback);
+				Inactive.emplace(appearance);
+			}
+			else
+			{
+				InnerDeserialize(key, it->value, unknownKeyCallback);
+			}
+		}
+	}
+private:
+	static constexpr std::wstring_view INACTIVE_KEY = L"inactive";
+};

--- a/Common/config/activeinactivetaskbarappearance.hpp
+++ b/Common/config/activeinactivetaskbarappearance.hpp
@@ -19,9 +19,7 @@ struct ActiveInactiveTaskbarAppearance : TaskbarAppearance {
 	inline void Serialize(Writer &writer) const
 	{
 		TaskbarAppearance::Serialize(writer);
-		if (Inactive.has_value()) {
-			rjh::Serialize(writer, Inactive.value(), INACTIVE_KEY);
-		}
+		rjh::Serialize(writer, Inactive.value(), INACTIVE_KEY);
 	}
 
 	inline void Deserialize(const rjh::value_t &obj, void (*unknownKeyCallback)(std::wstring_view))
@@ -35,9 +33,7 @@ struct ActiveInactiveTaskbarAppearance : TaskbarAppearance {
 			const auto key = rjh::ValueToStringView(it->name);
 			if (key == INACTIVE_KEY)
 			{
-				TaskbarAppearance appearance;
-				rjh::Deserialize(it->value, appearance, key, unknownKeyCallback);
-				Inactive.emplace(appearance);
+				rjh::Deserialize(it->value, Inactive, key, unknownKeyCallback);
 			}
 			else
 			{

--- a/Common/config/ruledtaskbarappearance.hpp
+++ b/Common/config/ruledtaskbarappearance.hpp
@@ -75,6 +75,7 @@ struct RuledTaskbarAppearance : OptionalTaskbarAppearance {
 	}
 
 	inline std::optional<TaskbarAppearance> FindRuleInner(const Window window) const
+	{
 		// This is the fastest because we do the less string manipulation, so always try it first
 		if (!ClassRules.empty())
 		{
@@ -176,7 +177,7 @@ private:
 	}
 
 	template<typename Hash, typename Equal, typename Alloc>
-	inline static void DeserializeMap(const rjh::value_t &obj, std::unordered_map<std::wstring, ActiveInactiveTaskbarAppearance, Hash, Equal, Alloc>& map, void (*unknownKeyCallback)(std::wstring_view))
+	inline static void DeserializeMap(const rjh::value_t &obj, std::unordered_map<std::wstring, ActiveInactiveTaskbarAppearance, Hash, Equal, Alloc> &map, void (*unknownKeyCallback)(std::wstring_view))
 	{
 		rjh::EnsureType(rj::Type::kObjectType, obj.GetType(), L"root node");
 

--- a/Common/config/ruledtaskbarappearance.hpp
+++ b/Common/config/ruledtaskbarappearance.hpp
@@ -63,6 +63,18 @@ struct RuledTaskbarAppearance : OptionalTaskbarAppearance {
 #ifdef _TRANSLUCENTTB_EXE
 	inline std::optional<TaskbarAppearance> FindRule(const Window window) const
 	{
+		const auto rule = FindRuleInner(window);
+		if (window.active())
+		{
+			return rule;
+		}
+		else
+		{
+			return rule.Inactive;
+		}
+	}
+
+	inline std::optional<TaskbarAppearance> FindRuleInner(const Window window) const
 		// This is the fastest because we do the less string manipulation, so always try it first
 		if (!ClassRules.empty())
 		{
@@ -70,13 +82,7 @@ struct RuledTaskbarAppearance : OptionalTaskbarAppearance {
 			{
 				if (const auto it = ClassRules.find(*className); it != ClassRules.end())
 				{
-					if (window.active()) {
-						return it->second;
-					}
-					else {
-						return it->second.Inactive;
-					}
-
+					return it->second;
 				}
 			}
 			else
@@ -93,12 +99,7 @@ struct RuledTaskbarAppearance : OptionalTaskbarAppearance {
 				{
 					if (const auto it = FileRules.find(file->filename().native()); it != FileRules.end())
 					{
-						if (window.active()) {
-							return it->second;
-						}
-						else {
-							return it->second.Inactive;
-						}
+						return it->second;
 					}
 				}
 				StdSystemErrorCatch(spdlog::level::warn, L"Failed to check if window process is part of window filter");
@@ -118,12 +119,7 @@ struct RuledTaskbarAppearance : OptionalTaskbarAppearance {
 				{
 					if (title->find(key) != std::wstring::npos)
 					{
-						if (window.active()) {
-							return value;
-						}
-						else {
-							return value.Inactive;
-						}
+						return value;
 					}
 				}
 			}

--- a/Common/config/ruledtaskbarappearance.hpp
+++ b/Common/config/ruledtaskbarappearance.hpp
@@ -80,7 +80,7 @@ struct RuledTaskbarAppearance : OptionalTaskbarAppearance {
 		}
 	}
 
-	inline std::optional<TaskbarAppearance> FindRuleInner(const Window window) const
+	inline std::optional<ActiveInactiveTaskbarAppearance> FindRuleInner(const Window window) const
 	{
 		// This is the fastest because we do the less string manipulation, so always try it first
 		if (!ClassRules.empty())

--- a/Common/config/ruledtaskbarappearance.hpp
+++ b/Common/config/ruledtaskbarappearance.hpp
@@ -63,15 +63,20 @@ struct RuledTaskbarAppearance : OptionalTaskbarAppearance {
 #ifdef _TRANSLUCENTTB_EXE
 	inline std::optional<TaskbarAppearance> FindRule(const Window window) const
 	{
-		const auto rule = FindRuleInner(window);
-		const auto active = window.active();
-		if (!window.active() && rule.Inactive)
+		if (const auto rule = FindRuleInner(window))
 		{
-			return rule.Inactive.value();
+			if (!window.active() && rule->Inactive)
+			{
+				return rule->Inactive.value();
+			}
+			else
+			{
+				return rule;
+			}
 		}
 		else
 		{
-			return rule;
+			return std::nullopt;
 		}
 	}
 

--- a/Common/config/ruledtaskbarappearance.hpp
+++ b/Common/config/ruledtaskbarappearance.hpp
@@ -64,13 +64,14 @@ struct RuledTaskbarAppearance : OptionalTaskbarAppearance {
 	inline std::optional<TaskbarAppearance> FindRule(const Window window) const
 	{
 		const auto rule = FindRuleInner(window);
-		if (window.active())
+		const auto active = window.active();
+		if (!window.active() && rule.Inactive)
 		{
-			return rule;
+			return rule.Inactive.value();
 		}
 		else
 		{
-			return rule.Inactive;
+			return rule;
 		}
 	}
 

--- a/TranslucentTB/windows/window.hpp
+++ b/TranslucentTB/windows/window.hpp
@@ -149,6 +149,11 @@ public:
 		return IsWindowVisible(m_WindowHandle);
 	}
 
+	inline bool active() const noexcept
+	{
+		return ForegroundWindow() == m_WindowHandle;
+	}
+
 	inline bool cloaked() const
 	{
 		const auto attr = get_attribute<DWMWA_CLOAKED>();

--- a/settings.schema.json
+++ b/settings.schema.json
@@ -44,10 +44,18 @@
       ]
     },
     "RuleSet": {
-      "type": "object",
-      "additionalProperties": {
+      "allOf": [
+        {
+          "properties": {
+            "inactive": {
+              "$ref": "#/$defs/TaskbarAppearance"
+            }
+          }
+        },
+        {
         "$ref": "#/$defs/TaskbarAppearance"
-      }
+        }
+      ]
     },
     "RuledTaskbarAppearance": {
       "allOf": [
@@ -56,13 +64,25 @@
             "rules": {
               "properties": {
                 "window_class": {
-                  "$ref": "#/$defs/RuleSet"
+                  "patternProperties": {
+                    "^.*$": {
+                      "$ref": "#/$defs/RuleSet"
+                    }
+                  }
                 },
                 "window_title": {
-                  "$ref": "#/$defs/RuleSet"
+                  "patternProperties": {
+                    "^.*$": {
+                      "$ref": "#/$defs/RuleSet"
+                    }
+                  }
                 },
                 "process_name": {
-                  "$ref": "#/$defs/RuleSet"
+                  "patternProperties": {
+                    "^.*$": {
+                      "$ref": "#/$defs/RuleSet"
+                    }
+                  }
                 }
               }
             }

--- a/settings.schema.json
+++ b/settings.schema.json
@@ -53,7 +53,7 @@
           }
         },
         {
-        "$ref": "#/$defs/TaskbarAppearance"
+          "$ref": "#/$defs/TaskbarAppearance"
         }
       ]
     },
@@ -64,24 +64,18 @@
             "rules": {
               "properties": {
                 "window_class": {
-                  "patternProperties": {
-                    "^.*$": {
+                  "additionalProperties": {
                       "$ref": "#/$defs/RuleSet"
-                    }
                   }
                 },
                 "window_title": {
-                  "patternProperties": {
-                    "^.*$": {
+                  "additionalProperties": {
                       "$ref": "#/$defs/RuleSet"
-                    }
                   }
                 },
                 "process_name": {
-                  "patternProperties": {
-                    "^.*$": {
+                  "additionalProperties": {
                       "$ref": "#/$defs/RuleSet"
-                    }
                   }
                 }
               }

--- a/settings.schema.json
+++ b/settings.schema.json
@@ -65,17 +65,17 @@
               "properties": {
                 "window_class": {
                   "additionalProperties": {
-                      "$ref": "#/$defs/RuleSet"
+                    "$ref": "#/$defs/RuleSet"
                   }
                 },
                 "window_title": {
                   "additionalProperties": {
-                      "$ref": "#/$defs/RuleSet"
+                    "$ref": "#/$defs/RuleSet"
                   }
                 },
                 "process_name": {
                   "additionalProperties": {
-                      "$ref": "#/$defs/RuleSet"
+                    "$ref": "#/$defs/RuleSet"
                   }
                 }
               }


### PR DESCRIPTION
This is a continuation of #513 to add support for overriding the configuration when the window is inactive, this is mainly useful for `maximized_window_appearance` and it is common for apps to have a different title bar color based on whether they are active or not, for example "Visual Studio Code".

In #513, rules have been introduced and this PR aims to allow each rule to define an `inactive` override when this rule is matched.

```json
"maximized_window_appearance": {
    "enabled": true,
    "accent": "acrylic",
    "color": "#00000000",
    "rules": {
      "process_name": {
        "Code.exe": {
          "accent": "opaque",
          "color": "#181818FF",
          "inactive": {
            "accent": "opaque",
            "color": "#1F1F1FFF",
          }
        }
      }
    }
  },
``` 