### PR TITLE
Update Traditional Chinese translation

### DIFF
--- a/Xaml/Strings/zh-TW/Resources.resw
+++ b/Xaml/Strings/zh-TW/Resources.resw
@@ -248,7 +248,7 @@
     <comment>Also used to generate the title of color picker windows</comment>
   </data>
   <data name="TrayFlyoutPage_TaskViewOpened.Text" xml:space="preserve">
-    <value>開啟任務檢視時</value>
+    <value>開啟工作檢視時</value>
     <comment>Also used to generate the title of color picker windows</comment>
   </data>
   <data name="TrayFlyoutPage_TipsAndTricks.Text" xml:space="preserve">


### PR DESCRIPTION
This PR revises the term "Task View" to match the translation used in Windows 11, which avoids confusion.