### PR TITLE
Support taskbar color preview via window messages

### DIFF
--- a/Common/constants.hpp
+++ b/Common/constants.hpp
@@ -53,6 +53,9 @@ static constexpr Util::null_terminated_wstring_view WM_TTBFORCEREFRESHTASKBAR = 
 // Sent by another instance of TranslucentTB to signal that it was started while this instance is running.
 static constexpr Util::null_terminated_wstring_view WM_TTBNEWINSTANCESTARTED = L"TTB_NewInstanceStarted";
 
+// Sent to the worker to apply taskbar color preview.
+static constexpr Util::null_terminated_wstring_view WM_TTBAPPLYCOLORPREVIEW = L"TTB_ApplyColorPreview";
+
 #pragma endregion
 
 #pragma region Window classes

--- a/TranslucentTB/taskbar/taskbarattributeworker.cpp
+++ b/TranslucentTB/taskbar/taskbarattributeworker.cpp
@@ -374,6 +374,14 @@ LRESULT TaskbarAttributeWorker::MessageHandler(UINT uMsg, WPARAM wParam, LPARAM 
 		OnForceRefreshTaskbar(reinterpret_cast<HWND>(lParam));
 		return 0;
 	}
+	else if (uMsg == m_ApplyColorPreview)
+	{
+		txmp::TaskbarState state = static_cast<txmp::TaskbarState>(wParam);
+		uint32_t rgba = static_cast<uint32_t>(lParam);
+		Util::Color color = Util::Color::FromRGBA(rgba);
+		ApplyColorPreview(state, color);
+		return 0;
+	}
 
 	return MessageWindow::MessageHandler(uMsg, wParam, lParam);
 }
@@ -1197,6 +1205,7 @@ TaskbarAttributeWorker::TaskbarAttributeWorker(ConfigManager &cfgManager, HINSTA
 	m_SearchVisibilityChangeMessage(Window::RegisterMessage(WM_TTBSEARCHVISIBILITYCHANGE)),
 	m_FindInStartVisibilityChangeMessage(Window::RegisterMessage(WM_TTBFINDINSTARTVISIBILITYCHANGE)),
 	m_ForceRefreshTaskbar(Window::RegisterMessage(WM_TTBFORCEREFRESHTASKBAR)),
+	m_ApplyColorPreview(Window::RegisterMessage(WM_TTBAPPLYCOLORPREVIEW)),
 	m_LastExplorerPid(0),
 	m_HookDll(storageFolder, cfgManager.GetConfig().CopyDlls.value_or(true), L"ExplorerHooks.dll"),
 	m_InjectExplorerHook(m_HookDll.GetProc<PFN_INJECT_EXPLORER_HOOK>("InjectExplorerHook")),

--- a/TranslucentTB/taskbar/taskbarattributeworker.cpp
+++ b/TranslucentTB/taskbar/taskbarattributeworker.cpp
@@ -379,7 +379,11 @@ LRESULT TaskbarAttributeWorker::MessageHandler(UINT uMsg, WPARAM wParam, LPARAM 
 		txmp::TaskbarState state = static_cast<txmp::TaskbarState>(wParam);
 		uint32_t rgba = static_cast<uint32_t>(lParam);
 		Util::Color color = Util::Color::FromRGBA(rgba);
-		ApplyColorPreview(state, color);
+		try {
+			ApplyColorPreview(state, color);
+		} catch (const std::out_of_range&) {
+			return 1;
+		}
 		return 0;
 	}
 

--- a/TranslucentTB/taskbar/taskbarattributeworker.hpp
+++ b/TranslucentTB/taskbar/taskbarattributeworker.hpp
@@ -131,6 +131,7 @@ private:
 	std::optional<UINT> m_SearchVisibilityChangeMessage;
 	std::optional<UINT> m_FindInStartVisibilityChangeMessage;
 	std::optional<UINT> m_ForceRefreshTaskbar;
+	std::optional<UINT> m_ApplyColorPreview;
 
 	// Explorer crash detection
 	std::chrono::steady_clock::time_point m_LastExplorerRestart;


### PR DESCRIPTION
Adds a handler for the new `WM_TTBAPPLYCOLORPREVIEW` message.

The handler unpacks the taskbar state from wParam and the RGBA color from lParam to apply the preview.

Works as expected in local tests : )