### PR TITLE
Added shortcut CTRL + ALT + SHIFT + F1 to Restore Dynamic State - ext…

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ A lightweight (uses a few MB of RAM and almost no CPU) utility that makes the Wi
 - Compatible with [RoundedTB](https://github.com/torchgm/RoundedTB)!
 - Compatible with [ExplorerPatcher](https://github.com/valinet/ExplorerPatcher)!
 
+## Keyboard Shortcuts
+
+- **CTRL + ALT + SHIFT + F1**: Resets the dynamic state. Use this to restore functionality if TranslucentTB loses its state after hibernation or restore.
+
 ## Screenshots
 
 <img src="https://i.imgur.com/QbG7KQA.png" alt="windows 11 acrylic" width="243"> <img src="https://i.imgur.com/zabZ52s.png" alt="windows 11 clear" width="243">

--- a/TranslucentTB/mainappwindow.cpp
+++ b/TranslucentTB/mainappwindow.cpp
@@ -8,10 +8,20 @@
 #include "../ProgramLog/log.hpp"
 #include "../ProgramLog/error/win32.hpp"
 
+constexpr int HOTKEY_RESET_DYNAMIC_STATE_ID = 1;
+
 LRESULT MainAppWindow::MessageHandler(UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
 	switch (uMsg)
 	{
+	case WM_HOTKEY:
+		if (wParam == HOTKEY_RESET_DYNAMIC_STATE_ID)
+		{
+			ResetDynamicStateRequested();
+			return 0;
+		}
+		break;
+
 	case WM_CLOSE:
 		Exit();
 		return 1;
@@ -320,6 +330,11 @@ MainAppWindow::MainAppWindow(Application &app, bool hideIconOverride, bool hasPa
 	m_HideIconOverride(hideIconOverride),
 	m_NewInstanceMessage(Window::RegisterMessage(WM_TTBNEWINSTANCESTARTED))
 {
+	if (!RegisterHotKey(handle(), HOTKEY_RESET_DYNAMIC_STATE_ID, MOD_CONTROL | MOD_ALT | MOD_SHIFT | MOD_NOREPEAT, VK_F1))
+	{
+		LastErrorHandle(spdlog::level::warn, L"Failed to register reset dynamic state hotkey");
+	}
+
 	RegisterMenuHandlers();
 
 	ConfigurationChanged();

--- a/Xaml/Strings/en-US/Resources.resw
+++ b/Xaml/Strings/en-US/Resources.resw
@@ -197,7 +197,7 @@
     <value>Open log file</value>
   </data>
   <data name="TrayFlyoutPage_Advanced_ResetDynamicState.Text" xml:space="preserve">
-    <value>Reset dynamic state</value>
+    <value>Reset dynamic state (^+%F1)</value>
   </data>
   <data name="TrayFlyoutPage_Advanced_ResetSettings.Text" xml:space="preserve">
     <value>Return to default settings</value>


### PR DESCRIPTION
Extremely useful after a hibernation/restore in W11 as finding the `Restore Dynamic State` manually requires too many context clicks