### PR TITLE
feat: Add Adaptive Opacity setting and contrast evaluation hook

### DIFF
--- a/Common/config/taskbarappearance.hpp
+++ b/Common/config/taskbarappearance.hpp
@@ -26,15 +26,17 @@ struct TaskbarAppearance {
 	Util::Color Color = { 0, 0, 0, 0 };
 	bool ShowPeek = true;
 	bool ShowLine = true;
+	bool AdaptiveOpacity = false;
 	float BlurRadius = 9.0f;
 
 	constexpr TaskbarAppearance() noexcept = default;
-	constexpr TaskbarAppearance(ACCENT_STATE accent, Util::Color color, bool showPeek, bool showLine, float blurRadius) noexcept :
+	constexpr TaskbarAppearance(ACCENT_STATE accent, Util::Color color, bool showPeek, bool showLine, float blurRadius, bool adaptiveOpacity = false) noexcept :
 		Accent(accent),
 		Color(color),
 		ShowPeek(showPeek),
 		ShowLine(showLine),
-		BlurRadius(blurRadius)
+		BlurRadius(blurRadius),
+		AdaptiveOpacity(adaptiveOpacity)
 	{ }
 
 #ifdef HAS_RAPIDJSON
@@ -45,6 +47,7 @@ struct TaskbarAppearance {
 		rjh::Serialize(writer, Color.ToString(), COLOR_KEY);
 		rjh::Serialize(writer, ShowPeek, SHOW_PEEK_KEY);
 		rjh::Serialize(writer, ShowLine, SHOW_LINE_KEY);
+		rjh::Serialize(writer, AdaptiveOpacity, ADAPTIVE_OPACITY_KEY);
 		rjh::Serialize(writer, BlurRadius, RADIUS_KEY);
 	}
 
@@ -91,6 +94,10 @@ protected:
 		{
 			rjh::Deserialize(val, ShowLine, key);
 		}
+		else if (key == ADAPTIVE_OPACITY_KEY)
+		{
+			rjh::Deserialize(val, AdaptiveOpacity, key);
+		}
 		else if (key == RADIUS_KEY)
 		{
 			rjh::Deserialize(val, BlurRadius, key);
@@ -120,6 +127,7 @@ private:
 	static constexpr std::wstring_view COLOR_KEY = L"color";
 	static constexpr std::wstring_view SHOW_PEEK_KEY = L"show_peek";
 	static constexpr std::wstring_view SHOW_LINE_KEY = L"show_line";
+	static constexpr std::wstring_view ADAPTIVE_OPACITY_KEY = L"adaptive_opacity";
 	static constexpr std::wstring_view RADIUS_KEY = L"blur_radius";
 #endif
 

--- a/TranslucentTB/taskbar/taskbarattributeworker.cpp
+++ b/TranslucentTB/taskbar/taskbarattributeworker.cpp
@@ -484,6 +484,26 @@ TaskbarAppearance TaskbarAttributeWorker::GetConfig(taskbar_iterator taskbar) co
 	return WithPreview(txmp::TaskbarState::Desktop, config.DesktopAppearance);
 }
 
+TaskbarAppearance TaskbarAttributeWorker::ApplyAdaptiveContrast(taskbar_iterator taskbar, TaskbarAppearance config) const
+{
+	if (!config.AdaptiveOpacity)
+	{
+		return config;
+	}
+
+	// =========================================================================
+	// CORE LOGIC STUB (ADAPTIVE OPACITY / CONTRAST CALCULATOR)
+	// =========================================================================
+	// When Adaptive Opacity is enabled:
+	// 1. Get taskbar window position: taskbar->second.Taskbar.TaskbarWindow.rect()
+	// 2. Sample background color / wallpaper luminance beneath the taskbar.
+	// 3. If luminance exceeds a threshold (light background), dynamically adjust
+	//    config.Color.A to increase opacity so white text/icons stay legible.
+	// =========================================================================
+
+	return config;
+}
+
 void TaskbarAttributeWorker::ShowAeroPeekButton(const TaskbarInfo &taskbar, bool show)
 {
 	if (const auto style = taskbar.PeekWindow.get_long_ptr(GWL_EXSTYLE))

--- a/TranslucentTB/taskbar/taskbarattributeworker.hpp
+++ b/TranslucentTB/taskbar/taskbarattributeworker.hpp
@@ -220,17 +220,17 @@ private:
 	static HMONITOR GetTaskbarMonitor(Window taskbar);
 	static TaskbarType GetTaskbarType(Window taskbar);
 
+	TaskbarAppearance ApplyAdaptiveContrast(taskbar_iterator taskbar, TaskbarAppearance config) const;
+
 	inline TaskbarAppearance WithPreview(txmp::TaskbarState state, const TaskbarAppearance &appearance) const
 	{
 		const auto &preview = m_ColorPreviews.at(static_cast<std::size_t>(state));
+		TaskbarAppearance result = appearance;
 		if (preview)
 		{
-			return { appearance.Accent, *preview, appearance.ShowPeek, appearance.ShowLine, appearance.BlurRadius };
+			result = { appearance.Accent, *preview, appearance.ShowPeek, appearance.ShowLine, appearance.BlurRadius, appearance.AdaptiveOpacity };
 		}
-		else
-		{
-			return appearance;
-		}
+		return ApplyAdaptiveContrast(taskbar, result);
 	}
 
 	inline static HMONITOR GetStartMenuMonitor() noexcept

--- a/Xaml/Pages/TrayFlyoutPage.cpp
+++ b/Xaml/Pages/TrayFlyoutPage.cpp
@@ -65,6 +65,11 @@ namespace winrt::TranslucentTB::Xaml::Pages::implementation
 						toggleItem.IsChecked(appearance.ShowLine());
 						toggleItem.IsEnabled(enabled);
 					}
+					else if (stringTag == L"AdaptiveOpacity")
+					{
+						toggleItem.IsChecked(appearance.AdaptiveOpacity());
+						toggleItem.IsEnabled(enabled);
+					}
 				}
 				else if (tag.try_as<hstring>() == L"Color")
 				{
@@ -315,6 +320,10 @@ namespace winrt::TranslucentTB::Xaml::Pages::implementation
 				else if (tag.try_as<hstring>() == L"ShowLine")
 				{
 					appearance.ShowLine(toggleItem.IsChecked());
+				}
+				else if (tag.try_as<hstring>() == L"AdaptiveOpacity")
+				{
+					appearance.AdaptiveOpacity(toggleItem.IsChecked());
 				}
 			}
 		}

--- a/Xaml/Pages/TrayFlyoutPage.xaml
+++ b/Xaml/Pages/TrayFlyoutPage.xaml
@@ -25,6 +25,7 @@
                 </MenuFlyoutSubItem.Icon>
                 <ToggleMenuFlyoutItem Tag="ShowPeek" x:Uid="TrayFlyoutPage_PeekButton" Style="{StaticResource MergeIconsToggleMenuFlyoutItem}" Click="AppearanceClicked" />
                 <ToggleMenuFlyoutItem Tag="ShowLine" x:Uid="TrayFlyoutPage_LineButton" Style="{StaticResource MergeIconsToggleMenuFlyoutItem}" Click="AppearanceClicked" />
+                <ToggleMenuFlyoutItem Tag="AdaptiveOpacity" x:Uid="TrayFlyoutPage_AdaptiveOpacity" Style="{StaticResource MergeIconsToggleMenuFlyoutItem}" Click="AppearanceClicked" />
                 <MenuFlyoutItem Tag="Color" x:Uid="TrayFlyoutPage_AccentColor" Style="{StaticResource MergeIconsMenuFlyoutItem}" Click="ColorClicked">
                     <MenuFlyoutItem.Icon>
                         <FontIcon Glyph="&#xE790;" />

--- a/Xaml/Strings/en-US/Resources.resw
+++ b/Xaml/Strings/en-US/Resources.resw
@@ -245,6 +245,9 @@
   <data name="TrayFlyoutPage_PeekButton.Text" xml:space="preserve">
     <value>Show Desktop Peek Button</value>
   </data>
+  <data name="TrayFlyoutPage_AdaptiveOpacity.Text" xml:space="preserve">
+    <value>Adaptive Opacity</value>
+  </data>
   <data name="TrayFlyoutPage_SearchOpened.Text" xml:space="preserve">
     <value>Search opened</value>
     <comment>Also used to generate the title of color picker windows</comment>

--- a/settings.schema.json
+++ b/settings.schema.json
@@ -25,6 +25,9 @@
         "show_line": {
           "type": "boolean"
         },
+        "adaptive_opacity": {
+          "type": "boolean"
+        },
         "blur_radius": {
           "type": "number",
           "minimum": 0,


### PR DESCRIPTION
This PR adds the architectural setup for an **Adaptive Opacity** feature in TranslucentTB:

- **Schema & Config**: Added daptive_opacity to settings.schema.json and TaskbarAppearance in 	askbarappearance.hpp with JSON serialization/deserialization.
- **UI Toggle**: Added an *Adaptive Opacity* toggle item to TrayFlyoutPage.xaml, string resource in Resources.resw, and delegate handlers in TrayFlyoutPage.cpp.
- **Core Logic Stub**: Introduced TaskbarAttributeWorker::ApplyAdaptiveContrast() in 	askbarattributeworker.cpp as the contrast evaluation hook before applying composition attributes to DWM / Explorer.