### PR TITLE
feat: add lightweight adaptive taskbar opacity

### DIFF
--- a/Common/config/activeinactivetaskbarappearance.hpp
+++ b/Common/config/activeinactivetaskbarappearance.hpp
@@ -10,8 +10,8 @@ struct ActiveInactiveTaskbarAppearance : TaskbarAppearance {
 	std::optional<TaskbarAppearance> Inactive;
 
 	constexpr ActiveInactiveTaskbarAppearance() noexcept = default;
-	constexpr ActiveInactiveTaskbarAppearance(std::optional<TaskbarAppearance> inactive, ACCENT_STATE accent, Util::Color color, bool showPeek, bool showLine, float blurRadius) noexcept :
-		TaskbarAppearance(accent, color, showPeek, showLine, blurRadius),
+	constexpr ActiveInactiveTaskbarAppearance(std::optional<TaskbarAppearance> inactive, ACCENT_STATE accent, Util::Color color, bool showPeek, bool showLine, float blurRadius, bool adaptiveOpacity = false) noexcept :
+		TaskbarAppearance(accent, color, showPeek, showLine, blurRadius, adaptiveOpacity),
 		Inactive(std::move(inactive))
 	{ }
 

--- a/Common/config/optionaltaskbarappearance.hpp
+++ b/Common/config/optionaltaskbarappearance.hpp
@@ -8,8 +8,8 @@ struct OptionalTaskbarAppearance : TaskbarAppearance {
 	bool Enabled = false;
 
 	constexpr OptionalTaskbarAppearance() noexcept = default;
-	constexpr OptionalTaskbarAppearance(bool enabled, ACCENT_STATE accent, Util::Color color, bool showPeek, bool showLine, float blurRadius) noexcept :
-		TaskbarAppearance(accent, color, showPeek, showLine, blurRadius),
+	constexpr OptionalTaskbarAppearance(bool enabled, ACCENT_STATE accent, Util::Color color, bool showPeek, bool showLine, float blurRadius, bool adaptiveOpacity = false) noexcept :
+		TaskbarAppearance(accent, color, showPeek, showLine, blurRadius, adaptiveOpacity),
 		Enabled(enabled)
 	{ }
 
@@ -40,7 +40,7 @@ struct OptionalTaskbarAppearance : TaskbarAppearance {
 
 	operator txmp::OptionalTaskbarAppearance() const
 	{
-		return { Enabled, static_cast<txmp::AccentState>(Accent), Color, ShowPeek, ShowLine, BlurRadius };
+		return { Enabled, static_cast<txmp::AccentState>(Accent), Color, ShowPeek, ShowLine, BlurRadius, AdaptiveOpacity };
 	}
 #endif
 

--- a/Common/config/ruledtaskbarappearance.hpp
+++ b/Common/config/ruledtaskbarappearance.hpp
@@ -21,8 +21,8 @@ struct RuledTaskbarAppearance : OptionalTaskbarAppearance {
 	win32::FilenameMap<ActiveInactiveTaskbarAppearance> FileRules;
 
 	RuledTaskbarAppearance() = default;
-	RuledTaskbarAppearance(std::unordered_map<std::wstring, ActiveInactiveTaskbarAppearance> classRules, std::unordered_map<std::wstring, ActiveInactiveTaskbarAppearance> titleRules, win32::FilenameMap<ActiveInactiveTaskbarAppearance> fileRules, bool enabled, ACCENT_STATE accent, Util::Color color, bool showPeek, bool showLine, float blurRadius) :
-		OptionalTaskbarAppearance(enabled, accent, color, showPeek, showLine, blurRadius),
+	RuledTaskbarAppearance(std::unordered_map<std::wstring, ActiveInactiveTaskbarAppearance> classRules, std::unordered_map<std::wstring, ActiveInactiveTaskbarAppearance> titleRules, win32::FilenameMap<ActiveInactiveTaskbarAppearance> fileRules, bool enabled, ACCENT_STATE accent, Util::Color color, bool showPeek, bool showLine, float blurRadius, bool adaptiveOpacity = false) :
+		OptionalTaskbarAppearance(enabled, accent, color, showPeek, showLine, blurRadius, adaptiveOpacity),
 		ClassRules(std::move(classRules)),
 		TitleRules(std::move(titleRules)),
 		FileRules(std::move(fileRules))

--- a/Common/config/taskbarappearance.hpp
+++ b/Common/config/taskbarappearance.hpp
@@ -26,15 +26,17 @@ struct TaskbarAppearance {
 	Util::Color Color = { 0, 0, 0, 0 };
 	bool ShowPeek = true;
 	bool ShowLine = true;
+	bool AdaptiveOpacity = false;
 	float BlurRadius = 9.0f;
 
 	constexpr TaskbarAppearance() noexcept = default;
-	constexpr TaskbarAppearance(ACCENT_STATE accent, Util::Color color, bool showPeek, bool showLine, float blurRadius) noexcept :
+	constexpr TaskbarAppearance(ACCENT_STATE accent, Util::Color color, bool showPeek, bool showLine, float blurRadius, bool adaptiveOpacity = false) noexcept :
 		Accent(accent),
 		Color(color),
 		ShowPeek(showPeek),
 		ShowLine(showLine),
-		BlurRadius(blurRadius)
+		BlurRadius(blurRadius),
+		AdaptiveOpacity(adaptiveOpacity)
 	{ }
 
 #ifdef HAS_RAPIDJSON
@@ -45,6 +47,7 @@ struct TaskbarAppearance {
 		rjh::Serialize(writer, Color.ToString(), COLOR_KEY);
 		rjh::Serialize(writer, ShowPeek, SHOW_PEEK_KEY);
 		rjh::Serialize(writer, ShowLine, SHOW_LINE_KEY);
+		rjh::Serialize(writer, AdaptiveOpacity, ADAPTIVE_OPACITY_KEY);
 		rjh::Serialize(writer, BlurRadius, RADIUS_KEY);
 	}
 
@@ -91,6 +94,10 @@ protected:
 		{
 			rjh::Deserialize(val, ShowLine, key);
 		}
+		else if (key == ADAPTIVE_OPACITY_KEY)
+		{
+			rjh::Deserialize(val, AdaptiveOpacity, key);
+		}
 		else if (key == RADIUS_KEY)
 		{
 			rjh::Deserialize(val, BlurRadius, key);
@@ -120,6 +127,7 @@ private:
 	static constexpr std::wstring_view COLOR_KEY = L"color";
 	static constexpr std::wstring_view SHOW_PEEK_KEY = L"show_peek";
 	static constexpr std::wstring_view SHOW_LINE_KEY = L"show_line";
+	static constexpr std::wstring_view ADAPTIVE_OPACITY_KEY = L"adaptive_opacity";
 	static constexpr std::wstring_view RADIUS_KEY = L"blur_radius";
 #endif
 

--- a/Common/config/taskbarappearance.hpp
+++ b/Common/config/taskbarappearance.hpp
@@ -35,8 +35,8 @@ struct TaskbarAppearance {
 		Color(color),
 		ShowPeek(showPeek),
 		ShowLine(showLine),
-		BlurRadius(blurRadius),
-		AdaptiveOpacity(adaptiveOpacity)
+		AdaptiveOpacity(adaptiveOpacity),
+		BlurRadius(blurRadius)
 	{ }
 
 #ifdef HAS_RAPIDJSON
@@ -138,12 +138,13 @@ public:
 		Color(winrtObj.Color()),
 		ShowPeek(winrtObj.ShowPeek()),
 		ShowLine(winrtObj.ShowLine()),
+		AdaptiveOpacity(winrtObj.AdaptiveOpacity()),
 		BlurRadius(winrtObj.BlurRadius())
 	{ }
 
 	operator txmp::TaskbarAppearance() const
 	{
-		return { static_cast<txmp::AccentState>(Accent), Color, ShowPeek, ShowLine, BlurRadius };
+		return { static_cast<txmp::AccentState>(Accent), Color, ShowPeek, ShowLine, BlurRadius, AdaptiveOpacity };
 	}
 #endif
 };

--- a/Common/util/adaptiveopacity.hpp
+++ b/Common/util/adaptiveopacity.hpp
@@ -1,0 +1,90 @@
+#pragma once
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "color.hpp"
+
+namespace Util::AdaptiveOpacity
+{
+	inline constexpr double BrightStart = 0.45;
+	inline constexpr double BrightFull = 0.85;
+	inline constexpr double NearWhite = 0.80;
+	inline constexpr double FullWhiteCoverage = 0.25;
+	inline constexpr uint8_t RiseStep = 48;
+	inline constexpr uint8_t FallStep = 20;
+
+	inline double Linearize(uint8_t channel) noexcept
+	{
+		const double value = static_cast<double>(channel) / 255.0;
+		return value <= 0.04045
+			? value / 12.92
+			: std::pow((value + 0.055) / 1.055, 2.4);
+	}
+
+	inline double RelativeLuminance(Util::Color color) noexcept
+	{
+		return
+			0.2126 * Linearize(color.R) +
+			0.7152 * Linearize(color.G) +
+			0.0722 * Linearize(color.B);
+	}
+
+	inline double BrightnessPressure(std::span<const Util::Color> samples) noexcept
+	{
+		if (samples.empty())
+		{
+			return 0.0;
+		}
+
+		std::vector<double> luminances;
+		luminances.reserve(samples.size());
+		std::size_t nearWhiteCount = 0;
+
+		for (const auto sample : samples)
+		{
+			const double luminance = RelativeLuminance(sample);
+			luminances.push_back(luminance);
+			if (luminance >= NearWhite)
+			{
+				++nearWhiteCount;
+			}
+		}
+
+		std::ranges::sort(luminances);
+		const std::size_t percentileIndex = (luminances.size() - 1) * 3 / 4;
+		const double percentilePressure = std::clamp(
+			(luminances[percentileIndex] - BrightStart) / (BrightFull - BrightStart),
+			0.0,
+			1.0);
+		const double whiteCoverage = static_cast<double>(nearWhiteCount) / static_cast<double>(samples.size());
+		const double coveragePressure = std::clamp(whiteCoverage / FullWhiteCoverage, 0.0, 1.0);
+		const double pressure = std::max(percentilePressure, coveragePressure);
+
+		return pressure * pressure * (3.0 - 2.0 * pressure);
+	}
+
+	inline uint8_t TargetAlpha(uint8_t baseAlpha, std::span<const Util::Color> samples) noexcept
+	{
+		const double pressure = BrightnessPressure(samples);
+		const double alpha = static_cast<double>(baseAlpha) + (255.0 - baseAlpha) * pressure;
+		return static_cast<uint8_t>(std::clamp(std::lround(alpha), static_cast<long>(baseAlpha), 255L));
+	}
+
+	inline uint8_t StepAlpha(uint8_t current, uint8_t target) noexcept
+	{
+		if (current < target)
+		{
+			return static_cast<uint8_t>(std::min<int>(target, current + RiseStep));
+		}
+
+		if (current > target)
+		{
+			return static_cast<uint8_t>(std::max<int>(target, current - FallStep));
+		}
+
+		return current;
+	}
+}

--- a/Common/util/adaptiveopacity.hpp
+++ b/Common/util/adaptiveopacity.hpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <optional>
 #include <span>
 #include <vector>
 
@@ -87,4 +88,22 @@ namespace Util::AdaptiveOpacity
 
 		return current;
 	}
+
+	class OpacityState
+	{
+	private:
+		std::optional<uint8_t> m_Alpha;
+
+	public:
+		uint8_t Value(uint8_t baseAlpha) const noexcept
+		{
+			return std::max(baseAlpha, m_Alpha.value_or(baseAlpha));
+		}
+
+		void Update(uint8_t baseAlpha, std::span<const Util::Color> samples) noexcept
+		{
+			const uint8_t current = Value(baseAlpha);
+			m_Alpha = StepAlpha(current, TargetAlpha(baseAlpha, samples));
+		}
+	};
 }

--- a/Tests/Tests.vcxproj
+++ b/Tests/Tests.vcxproj
@@ -31,6 +31,7 @@
     <ClCompile Include="config\rapidjsonhelper.cpp" />
     <ClCompile Include="config\taskbarappearance.cpp" />
     <ClCompile Include="util\color.cpp" />
+    <ClCompile Include="util\adaptiveopacity.cpp" />
     <ClCompile Include="util\numbers.cpp" />
     <ClCompile Include="util\strings.cpp" />
     <ClCompile Include="version.cpp" />

--- a/Tests/Tests.vcxproj
+++ b/Tests/Tests.vcxproj
@@ -19,6 +19,7 @@
     <ClCompile>
       <PreprocessorDefinitions>GTEST_LINKED_AS_SHARED_LIBRARY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4275;4389;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <AdditionalIncludeDirectories>$(ProjectDir)..\Xaml\Generated Files;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <AdditionalDependencies>gmock_main.lib;ole32.lib;oleaut32.lib;runtimeobject.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -28,6 +29,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="config\rapidjsonhelper.cpp" />
+    <ClCompile Include="config\taskbarappearance.cpp" />
     <ClCompile Include="util\color.cpp" />
     <ClCompile Include="util\numbers.cpp" />
     <ClCompile Include="util\strings.cpp" />

--- a/Tests/Tests.vcxproj
+++ b/Tests/Tests.vcxproj
@@ -30,6 +30,7 @@
   <ItemGroup>
     <ClCompile Include="config\rapidjsonhelper.cpp" />
     <ClCompile Include="config\taskbarappearance.cpp" />
+    <ClCompile Include="taskbar\taskbarbackgroundsampler.cpp" />
     <ClCompile Include="util\color.cpp" />
     <ClCompile Include="util\adaptiveopacity.cpp" />
     <ClCompile Include="util\numbers.cpp" />

--- a/Tests/Tests.vcxproj.filters
+++ b/Tests/Tests.vcxproj.filters
@@ -19,6 +19,9 @@
     <ClCompile Include="util\color.cpp">
       <Filter>Util Tests</Filter>
     </ClCompile>
+    <ClCompile Include="util\adaptiveopacity.cpp">
+      <Filter>Util Tests</Filter>
+    </ClCompile>
     <ClCompile Include="config\rapidjsonhelper.cpp">
       <Filter>Config Tests</Filter>
     </ClCompile>

--- a/Tests/Tests.vcxproj.filters
+++ b/Tests/Tests.vcxproj.filters
@@ -7,6 +7,9 @@
     <Filter Include="Config Tests">
       <UniqueIdentifier>{3268f330-639d-4e82-8928-d43f800a0cb4}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Taskbar Tests">
+      <UniqueIdentifier>{ef8f72f2-b22d-481f-bfe4-3208113e14cd}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="util\numbers.cpp">
@@ -27,6 +30,9 @@
     </ClCompile>
     <ClCompile Include="config\taskbarappearance.cpp">
       <Filter>Config Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="taskbar\taskbarbackgroundsampler.cpp">
+      <Filter>Taskbar Tests</Filter>
     </ClCompile>
     <ClCompile Include="version.cpp" />
   </ItemGroup>

--- a/Tests/Tests.vcxproj.filters
+++ b/Tests/Tests.vcxproj.filters
@@ -22,6 +22,9 @@
     <ClCompile Include="config\rapidjsonhelper.cpp">
       <Filter>Config Tests</Filter>
     </ClCompile>
+    <ClCompile Include="config\taskbarappearance.cpp">
+      <Filter>Config Tests</Filter>
+    </ClCompile>
     <ClCompile Include="version.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests/config/taskbarappearance.cpp
+++ b/Tests/config/taskbarappearance.cpp
@@ -1,0 +1,63 @@
+#include <gtest/gtest.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+#include "config/taskbarappearance.hpp"
+#include "../../Xaml/Models/Primitives/TaskbarAppearance.h"
+
+namespace
+{
+	using encoding = rj::UTF16LE<>;
+	using document = rj::GenericDocument<encoding>;
+	using string_buffer = rj::GenericStringBuffer<encoding>;
+	using writer = rj::Writer<string_buffer, encoding, encoding>;
+}
+
+TEST(Config_TaskbarAppearance, AdaptiveOpacityDefaultsToFalse)
+{
+	EXPECT_FALSE(TaskbarAppearance {}.AdaptiveOpacity);
+}
+
+TEST(Config_TaskbarAppearance, AdaptiveOpacityDeserializesFromJson)
+{
+	document json;
+	json.Parse(LR"({"adaptive_opacity":true})");
+	ASSERT_FALSE(json.HasParseError());
+
+	TaskbarAppearance appearance;
+	appearance.Deserialize(json, nullptr);
+
+	EXPECT_TRUE(appearance.AdaptiveOpacity);
+}
+
+TEST(Config_TaskbarAppearance, AdaptiveOpacitySerializesToJson)
+{
+	TaskbarAppearance appearance;
+	appearance.AdaptiveOpacity = true;
+
+	string_buffer buffer;
+	writer jsonWriter(buffer);
+	jsonWriter.StartObject();
+	appearance.Serialize(jsonWriter);
+	jsonWriter.EndObject();
+
+	document json;
+	json.Parse(buffer.GetString());
+	ASSERT_FALSE(json.HasParseError());
+	ASSERT_TRUE(json.HasMember(L"adaptive_opacity"));
+	EXPECT_TRUE(json[L"adaptive_opacity"].GetBool());
+}
+
+TEST(Config_TaskbarAppearance, AdaptiveOpacityDeserializesFromWinRT)
+{
+	const auto winrtAppearance = winrt::make<winrt::TranslucentTB::Xaml::Models::Primitives::implementation::TaskbarAppearance>(
+		txmp::AccentState::Clear,
+		winrt::Windows::UI::Color { 0x40, 0x10, 0x20, 0x30 },
+		true,
+		false,
+		9.0f,
+		true);
+	const TaskbarAppearance restored(winrtAppearance);
+
+	EXPECT_TRUE(restored.AdaptiveOpacity);
+}

--- a/Tests/taskbar/taskbarbackgroundsampler.cpp
+++ b/Tests/taskbar/taskbarbackgroundsampler.cpp
@@ -1,0 +1,64 @@
+#include <gtest/gtest.h>
+
+#include "../../TranslucentTB/taskbar/taskbarbackgroundsampler.hpp"
+
+namespace
+{
+	constexpr RECT Monitor { 0, 0, 1920, 1080 };
+}
+
+TEST(TaskbarBackgroundSampler, SamplesAboveBottomTaskbar)
+{
+	const auto points = TaskbarBackgroundSampler::SamplePoints({ 0, 1032, 1920, 1080 }, Monitor);
+	ASSERT_TRUE(points);
+
+	for (const auto point : *points)
+	{
+		EXPECT_GE(point.x, Monitor.left);
+		EXPECT_LT(point.x, Monitor.right);
+		EXPECT_LT(point.y, 1032);
+		EXPECT_GE(point.y, Monitor.top);
+	}
+}
+
+TEST(TaskbarBackgroundSampler, SamplesBelowTopTaskbar)
+{
+	const auto points = TaskbarBackgroundSampler::SamplePoints({ 0, 0, 1920, 48 }, Monitor);
+	ASSERT_TRUE(points);
+
+	for (const auto point : *points)
+	{
+		EXPECT_GT(point.y, 47);
+		EXPECT_LT(point.y, Monitor.bottom);
+	}
+}
+
+TEST(TaskbarBackgroundSampler, SamplesRightOfLeftTaskbar)
+{
+	const auto points = TaskbarBackgroundSampler::SamplePoints({ 0, 0, 48, 1080 }, Monitor);
+	ASSERT_TRUE(points);
+
+	for (const auto point : *points)
+	{
+		EXPECT_GT(point.x, 47);
+		EXPECT_LT(point.x, Monitor.right);
+	}
+}
+
+TEST(TaskbarBackgroundSampler, SamplesLeftOfRightTaskbar)
+{
+	const auto points = TaskbarBackgroundSampler::SamplePoints({ 1872, 0, 1920, 1080 }, Monitor);
+	ASSERT_TRUE(points);
+
+	for (const auto point : *points)
+	{
+		EXPECT_LT(point.x, 1872);
+		EXPECT_GE(point.x, Monitor.left);
+	}
+}
+
+TEST(TaskbarBackgroundSampler, RejectsEmptyOrOffMonitorRectangles)
+{
+	EXPECT_FALSE(TaskbarBackgroundSampler::SamplePoints({ 0, 0, 0, 0 }, Monitor));
+	EXPECT_FALSE(TaskbarBackgroundSampler::SamplePoints({ 2000, 1100, 2100, 1200 }, Monitor));
+}

--- a/Tests/util/adaptiveopacity.cpp
+++ b/Tests/util/adaptiveopacity.cpp
@@ -79,3 +79,22 @@ TEST(Util_AdaptiveOpacity, SmoothingRisesFasterThanItFalls)
 	EXPECT_GT(risen - 96, 255 - fallen);
 	EXPECT_EQ(StepAlpha(128, 128), 128);
 }
+
+TEST(Util_AdaptiveOpacity, CachedAlphaChangesOnlyWhenSamplesAreUpdated)
+{
+	OpacityState state;
+	const std::array white { Util::Color { 255, 255, 255 } };
+	const std::array dark { Util::Color { 0, 0, 0 } };
+
+	EXPECT_EQ(state.Value(96), 96);
+
+	state.Update(96, white);
+	const auto brightAlpha = state.Value(96);
+	EXPECT_GT(brightAlpha, 96);
+
+	// Reading the cached value cannot react to a changed background.
+	EXPECT_EQ(state.Value(96), brightAlpha);
+
+	state.Update(96, dark);
+	EXPECT_LT(state.Value(96), brightAlpha);
+}

--- a/Tests/util/adaptiveopacity.cpp
+++ b/Tests/util/adaptiveopacity.cpp
@@ -1,0 +1,81 @@
+#include <array>
+#include <gtest/gtest.h>
+
+#include "util/adaptiveopacity.hpp"
+
+using namespace Util::AdaptiveOpacity;
+
+TEST(Util_AdaptiveOpacity, RelativeLuminanceUsesLinearSrgb)
+{
+	EXPECT_NEAR(RelativeLuminance({ 255, 255, 255 }), 1.0, 1e-6);
+	EXPECT_NEAR(RelativeLuminance({ 0, 0, 0 }), 0.0, 1e-6);
+	EXPECT_NEAR(RelativeLuminance({ 127, 127, 127 }), 0.2122, 0.002);
+}
+
+TEST(Util_AdaptiveOpacity, EmptySamplesHaveNoBrightnessPressure)
+{
+	EXPECT_DOUBLE_EQ(BrightnessPressure({}), 0.0);
+}
+
+TEST(Util_AdaptiveOpacity, DarkSamplesKeepConfiguredAlpha)
+{
+	const std::array samples {
+		Util::Color { 0, 0, 0 },
+		Util::Color { 32, 32, 32 },
+		Util::Color { 64, 64, 64 }
+	};
+
+	EXPECT_EQ(TargetAlpha(96, samples), 96);
+}
+
+TEST(Util_AdaptiveOpacity, WhiteSamplesReachFullAlpha)
+{
+	const std::array samples {
+		Util::Color { 255, 255, 255 },
+		Util::Color { 250, 250, 250 }
+	};
+
+	EXPECT_EQ(TargetAlpha(96, samples), 255);
+}
+
+TEST(Util_AdaptiveOpacity, WhiteCoverageProtectsPartOfTaskbar)
+{
+	const std::array samples {
+		Util::Color { 20, 20, 20 },
+		Util::Color { 20, 20, 20 },
+		Util::Color { 20, 20, 20 },
+		Util::Color { 255, 255, 255 }
+	};
+
+	EXPECT_EQ(TargetAlpha(96, samples), 255);
+}
+
+TEST(Util_AdaptiveOpacity, BrightnessResponseIsMonotonic)
+{
+	const std::array gray { Util::Color { 160, 160, 160 } };
+	const std::array bright { Util::Color { 210, 210, 210 } };
+	const std::array white { Util::Color { 255, 255, 255 } };
+
+	EXPECT_LE(TargetAlpha(96, gray), TargetAlpha(96, bright));
+	EXPECT_LE(TargetAlpha(96, bright), TargetAlpha(96, white));
+}
+
+TEST(Util_AdaptiveOpacity, AlphaNeverDropsBelowConfiguredFloor)
+{
+	const std::array dark { Util::Color { 0, 0, 0 } };
+	const std::array white { Util::Color { 255, 255, 255 } };
+
+	EXPECT_EQ(TargetAlpha(220, dark), 220);
+	EXPECT_GE(TargetAlpha(220, white), 220);
+}
+
+TEST(Util_AdaptiveOpacity, SmoothingRisesFasterThanItFalls)
+{
+	const auto risen = StepAlpha(96, 255);
+	const auto fallen = StepAlpha(255, 96);
+
+	EXPECT_GT(risen, 96);
+	EXPECT_LT(fallen, 255);
+	EXPECT_GT(risen - 96, 255 - fallen);
+	EXPECT_EQ(StepAlpha(128, 128), 128);
+}

--- a/TranslucentTB/TranslucentTB.vcxproj
+++ b/TranslucentTB/TranslucentTB.vcxproj
@@ -86,6 +86,7 @@
     <ClCompile Include="mainappwindow.cpp" />
     <ClCompile Include="managers\startupmanager.cpp" />
     <ClCompile Include="taskbar\taskbarattributeworker.cpp" />
+    <ClCompile Include="taskbar\taskbarbackgroundsampler.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="tray\basecontextmenu.cpp" />
     <ClCompile Include="uwp\basexamlpagehost.cpp" />
@@ -112,6 +113,7 @@
     <ClInclude Include="tray\basecontextmenu.hpp" />
     <ClInclude Include="tray\traycontextmenu.hpp" />
     <ClInclude Include="taskbar\taskbarattributeworker.hpp" />
+    <ClInclude Include="taskbar\taskbarbackgroundsampler.hpp" />
     <ClInclude Include="uwp\basexamlpagehost.hpp" />
     <ClInclude Include="uwp\dynamicdependency.hpp" />
     <ClInclude Include="uwp\xamldragregion.hpp" />

--- a/TranslucentTB/TranslucentTB.vcxproj.filters
+++ b/TranslucentTB/TranslucentTB.vcxproj.filters
@@ -36,6 +36,9 @@
     <ClCompile Include="taskbar\taskbarattributeworker.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="taskbar\taskbarbackgroundsampler.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="mainappwindow.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -93,6 +96,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="taskbar\taskbarattributeworker.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="taskbar\taskbarbackgroundsampler.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="uwp\xamlpagehost.hpp">

--- a/TranslucentTB/taskbar/taskbarattributeworker.cpp
+++ b/TranslucentTB/taskbar/taskbarattributeworker.cpp
@@ -4,6 +4,7 @@
 #include <tlhelp32.h>
 
 #include "constants.hpp"
+#include "taskbarbackgroundsampler.hpp"
 #include "../localization.hpp"
 #include "../uwp/uwp.hpp"
 #include "../../ProgramLog/error/win32.hpp"
@@ -12,6 +13,7 @@
 #include "undoc/user32.hpp"
 #include "undoc/winuser.hpp"
 #include "win32.hpp"
+#include "util/adaptiveopacity.hpp"
 #include "winrt/Windows.Foundation.h"
 #include "winrt/Windows.Foundation.Metadata.h"
 
@@ -340,6 +342,11 @@ LRESULT TaskbarAttributeWorker::MessageHandler(UINT uMsg, WPARAM wParam, LPARAM 
 	{
 		return OnPowerBroadcast(reinterpret_cast<const POWERBROADCAST_SETTING *>(lParam));
 	}
+	else if (uMsg == WM_TIMER && wParam == AdaptiveOpacityTimer)
+	{
+		RefreshAllAttributes();
+		return 0;
+	}
 	else if (uMsg == m_TaskbarCreatedMessage)
 	{
 		MessagePrint(spdlog::level::debug, L"Main taskbar got created, refreshing...");
@@ -391,7 +398,7 @@ LRESULT TaskbarAttributeWorker::MessageHandler(UINT uMsg, WPARAM wParam, LPARAM 
 	return MessageWindow::MessageHandler(uMsg, wParam, lParam);
 }
 
-TaskbarAppearance TaskbarAttributeWorker::GetConfig(taskbar_iterator taskbar) const
+TaskbarAppearance TaskbarAttributeWorker::SelectConfig(taskbar_iterator taskbar) const
 {
 	const auto& config = m_ConfigManager.GetConfig();
 
@@ -484,24 +491,85 @@ TaskbarAppearance TaskbarAttributeWorker::GetConfig(taskbar_iterator taskbar) co
 	return WithPreview(txmp::TaskbarState::Desktop, config.DesktopAppearance);
 }
 
-TaskbarAppearance TaskbarAttributeWorker::ApplyAdaptiveContrast(taskbar_iterator taskbar, TaskbarAppearance config) const
+TaskbarAppearance TaskbarAttributeWorker::GetConfig(taskbar_iterator taskbar)
+{
+	return ApplyAdaptiveOpacity(taskbar, SelectConfig(taskbar));
+}
+
+TaskbarAppearance TaskbarAttributeWorker::ApplyAdaptiveOpacity(taskbar_iterator taskbar, TaskbarAppearance config)
 {
 	if (!config.AdaptiveOpacity)
 	{
+		m_AdaptiveOpacityStates.erase(taskbar->first);
 		return config;
 	}
 
-	// =========================================================================
-	// CORE LOGIC STUB (ADAPTIVE OPACITY / CONTRAST CALCULATOR)
-	// =========================================================================
-	// When Adaptive Opacity is enabled:
-	// 1. Get taskbar window position: taskbar->second.Taskbar.TaskbarWindow.rect()
-	// 2. Sample background color / wallpaper luminance beneath the taskbar.
-	// 3. If luminance exceeds a threshold (light background), dynamically adjust
-	//    config.Color.A to increase opacity so white text/icons stay legible.
-	// =========================================================================
+	const auto [state, inserted] = m_AdaptiveOpacityStates.try_emplace(
+		taskbar->first,
+		AdaptiveOpacityState { config.Color.A, {} });
+	state->second.Alpha = std::max(state->second.Alpha, config.Color.A);
 
+	const auto now = std::chrono::steady_clock::now();
+	if (!inserted && now - state->second.LastSample < std::chrono::milliseconds(AdaptiveOpacityIntervalMs))
+	{
+		config.Color.A = state->second.Alpha;
+		return config;
+	}
+
+	const auto taskbarRect = taskbar->second.Taskbar.TaskbarWindow.rect();
+	MONITORINFO monitorInfo { .cbSize = sizeof(monitorInfo) };
+	if (!taskbarRect || !GetMonitorInfo(taskbar->first, &monitorInfo))
+	{
+		state->second = { config.Color.A, now };
+		return config;
+	}
+
+	const auto samples = TaskbarBackgroundSampler::Sample(*taskbarRect, monitorInfo.rcMonitor);
+	if (!samples)
+	{
+		state->second = { config.Color.A, now };
+		return config;
+	}
+
+	const uint8_t target = Util::AdaptiveOpacity::TargetAlpha(config.Color.A, *samples);
+	state->second.Alpha = Util::AdaptiveOpacity::StepAlpha(state->second.Alpha, target);
+	state->second.LastSample = now;
+	config.Color.A = state->second.Alpha;
 	return config;
+}
+
+void TaskbarAttributeWorker::UpdateAdaptiveOpacityTimer()
+{
+	bool enabled = false;
+	for (auto taskbar = m_Taskbars.begin(); taskbar != m_Taskbars.end(); ++taskbar)
+	{
+		if (SelectConfig(taskbar).AdaptiveOpacity)
+		{
+			enabled = true;
+			break;
+		}
+	}
+
+	if (enabled && !m_AdaptiveOpacityTimerActive)
+	{
+		m_AdaptiveOpacityTimerActive = SetTimer(m_WindowHandle, AdaptiveOpacityTimer, AdaptiveOpacityIntervalMs, nullptr) != 0;
+		if (!m_AdaptiveOpacityTimerActive)
+		{
+			LastErrorHandle(spdlog::level::warn, L"Failed to start adaptive opacity timer");
+		}
+	}
+	else if (!enabled && m_AdaptiveOpacityTimerActive)
+	{
+		KillTimer(m_WindowHandle, AdaptiveOpacityTimer);
+		m_AdaptiveOpacityTimerActive = false;
+		m_AdaptiveOpacityStates.clear();
+	}
+}
+
+void TaskbarAttributeWorker::ConfigurationChanged()
+{
+	m_AdaptiveOpacityStates.clear();
+	RefreshAllAttributes();
 }
 
 void TaskbarAttributeWorker::ShowAeroPeekButton(const TaskbarInfo &taskbar, bool show)
@@ -659,6 +727,8 @@ void TaskbarAttributeWorker::RefreshAttribute(taskbar_iterator taskbar)
 			ShowAeroPeekButton(taskbarInfo, cfg.ShowPeek);
 		}
 	}
+
+	UpdateAdaptiveOpacityTimer();
 }
 
 void TaskbarAttributeWorker::RefreshAllAttributes()
@@ -1245,6 +1315,7 @@ TaskbarAttributeWorker::TaskbarAttributeWorker(ConfigManager &cfgManager, HINSTA
 	m_disableAttributeRefreshReply(false),
 	m_ResettingState(false),
 	m_ResetStateReentered(false),
+	m_AdaptiveOpacityTimerActive(false),
 	m_TaskbarType(TaskbarType::Unknown),
 	m_CurrentStartMonitor(nullptr),
 	m_CurrentSearchMonitor(nullptr),
@@ -1441,7 +1512,10 @@ void TaskbarAttributeWorker::ResetState(bool manual)
 		m_CurrentFindInStartMonitor = nullptr;
 		m_ForegroundWindow = Window::NullWindow;
 
+		KillTimer(m_WindowHandle, AdaptiveOpacityTimer);
+		m_AdaptiveOpacityTimerActive = false;
 		m_Taskbars.clear();
+		m_AdaptiveOpacityStates.clear();
 		m_NormalTaskbars.clear();
 
 		m_TaskbarService = nullptr;
@@ -1591,6 +1665,8 @@ void TaskbarAttributeWorker::ResetState(bool manual)
 
 TaskbarAttributeWorker::~TaskbarAttributeWorker() noexcept(false)
 {
+	KillTimer(m_WindowHandle, AdaptiveOpacityTimer);
+	m_AdaptiveOpacityTimerActive = false;
 	m_disableAttributeRefreshReply = true;
 	UnregisterTaskViewCallbacks();
 	UnregisterSearchCallbacks();

--- a/TranslucentTB/taskbar/taskbarattributeworker.cpp
+++ b/TranslucentTB/taskbar/taskbarattributeworker.cpp
@@ -344,6 +344,7 @@ LRESULT TaskbarAttributeWorker::MessageHandler(UINT uMsg, WPARAM wParam, LPARAM 
 	}
 	else if (uMsg == WM_TIMER && wParam == AdaptiveOpacityTimer)
 	{
+		SampleAdaptiveOpacity();
 		RefreshAllAttributes();
 		return 0;
 	}
@@ -504,38 +505,42 @@ TaskbarAppearance TaskbarAttributeWorker::ApplyAdaptiveOpacity(taskbar_iterator 
 		return config;
 	}
 
-	const auto [state, inserted] = m_AdaptiveOpacityStates.try_emplace(
-		taskbar->first,
-		AdaptiveOpacityState { config.Color.A, {} });
-	state->second.Alpha = std::max(state->second.Alpha, config.Color.A);
-
-	const auto now = std::chrono::steady_clock::now();
-	if (!inserted && now - state->second.LastSample < std::chrono::milliseconds(AdaptiveOpacityIntervalMs))
+	if (const auto state = m_AdaptiveOpacityStates.find(taskbar->first); state != m_AdaptiveOpacityStates.end())
 	{
-		config.Color.A = state->second.Alpha;
-		return config;
+		config.Color.A = state->second.Value(config.Color.A);
 	}
 
-	const auto taskbarRect = taskbar->second.Taskbar.TaskbarWindow.rect();
-	MONITORINFO monitorInfo { .cbSize = sizeof(monitorInfo) };
-	if (!taskbarRect || !GetMonitorInfo(taskbar->first, &monitorInfo))
-	{
-		state->second = { config.Color.A, now };
-		return config;
-	}
-
-	const auto samples = TaskbarBackgroundSampler::Sample(*taskbarRect, monitorInfo.rcMonitor);
-	if (!samples)
-	{
-		state->second = { config.Color.A, now };
-		return config;
-	}
-
-	const uint8_t target = Util::AdaptiveOpacity::TargetAlpha(config.Color.A, *samples);
-	state->second.Alpha = Util::AdaptiveOpacity::StepAlpha(state->second.Alpha, target);
-	state->second.LastSample = now;
-	config.Color.A = state->second.Alpha;
 	return config;
+}
+
+void TaskbarAttributeWorker::SampleAdaptiveOpacity()
+{
+	for (auto taskbar = m_Taskbars.begin(); taskbar != m_Taskbars.end(); ++taskbar)
+	{
+		const auto config = SelectConfig(taskbar);
+		if (!config.AdaptiveOpacity)
+		{
+			m_AdaptiveOpacityStates.erase(taskbar->first);
+			continue;
+		}
+
+		const auto taskbarRect = taskbar->second.Taskbar.TaskbarWindow.rect();
+		MONITORINFO monitorInfo { .cbSize = sizeof(monitorInfo) };
+		if (!taskbarRect || !GetMonitorInfo(taskbar->first, &monitorInfo))
+		{
+			m_AdaptiveOpacityStates.erase(taskbar->first);
+			continue;
+		}
+
+		const auto samples = TaskbarBackgroundSampler::Sample(*taskbarRect, monitorInfo.rcMonitor);
+		if (!samples)
+		{
+			m_AdaptiveOpacityStates.erase(taskbar->first);
+			continue;
+		}
+
+		m_AdaptiveOpacityStates[taskbar->first].Update(config.Color.A, *samples);
+	}
 }
 
 void TaskbarAttributeWorker::UpdateAdaptiveOpacityTimer()

--- a/TranslucentTB/taskbar/taskbarattributeworker.cpp
+++ b/TranslucentTB/taskbar/taskbarattributeworker.cpp
@@ -484,6 +484,26 @@ TaskbarAppearance TaskbarAttributeWorker::GetConfig(taskbar_iterator taskbar) co
 	return WithPreview(txmp::TaskbarState::Desktop, config.DesktopAppearance);
 }
 
+TaskbarAppearance TaskbarAttributeWorker::ApplyAdaptiveContrast(taskbar_iterator taskbar, TaskbarAppearance config) const
+{
+	if (!config.AdaptiveOpacity)
+	{
+		return config;
+	}
+
+	// =========================================================================
+	// CORE LOGIC STUB (ADAPTIVE OPACITY / CONTRAST CALCULATOR)
+	// =========================================================================
+	// When Adaptive Opacity is enabled:
+	// 1. Get taskbar window position: taskbar->second.Taskbar.TaskbarWindow.rect()
+	// 2. Sample background color / wallpaper luminance beneath the taskbar.
+	// 3. If luminance exceeds a threshold (light background), dynamically adjust
+	//    config.Color.A to increase opacity so white text/icons stay legible.
+	// =========================================================================
+
+	return config;
+}
+
 void TaskbarAttributeWorker::ShowAeroPeekButton(const TaskbarInfo &taskbar, bool show)
 {
 	if (const auto style = taskbar.PeekWindow.get_long_ptr(GWL_EXSTYLE))

--- a/TranslucentTB/taskbar/taskbarattributeworker.hpp
+++ b/TranslucentTB/taskbar/taskbarattributeworker.hpp
@@ -62,6 +62,14 @@ private:
 		HMONITOR monitor;
 	};
 
+	struct AdaptiveOpacityState {
+		uint8_t Alpha;
+		std::chrono::steady_clock::time_point LastSample;
+	};
+
+	inline static constexpr UINT_PTR AdaptiveOpacityTimer = 1;
+	inline static constexpr UINT AdaptiveOpacityIntervalMs = 1000;
+
 	// future improvements:
 	// - better aero peek support: detect current peeked to window and include in calculation
 	// - notification for owner changes
@@ -85,12 +93,14 @@ private:
 	bool m_disableAttributeRefreshReply;
 	bool m_ResettingState;
 	bool m_ResetStateReentered;
+	bool m_AdaptiveOpacityTimerActive;
 	HMONITOR m_CurrentStartMonitor;
 	HMONITOR m_CurrentSearchMonitor;
 	HMONITOR m_CurrentFindInStartMonitor;
 	Window m_ForegroundWindow;
 	TaskbarType m_TaskbarType;
 	std::unordered_map<HMONITOR, MonitorInfo> m_Taskbars;
+	std::unordered_map<HMONITOR, AdaptiveOpacityState> m_AdaptiveOpacityStates;
 	std::unordered_set<Window> m_NormalTaskbars;
 	ConfigManager &m_ConfigManager;
 
@@ -179,7 +189,9 @@ private:
 	LRESULT MessageHandler(UINT uMsg, WPARAM wParam, LPARAM lParam) override;
 
 	// Config
-	TaskbarAppearance GetConfig(taskbar_iterator taskbar) const;
+	TaskbarAppearance SelectConfig(taskbar_iterator taskbar) const;
+	TaskbarAppearance GetConfig(taskbar_iterator taskbar);
+	void UpdateAdaptiveOpacityTimer();
 
 	// Attribute
 	void ShowAeroPeekButton(const TaskbarInfo &taskbar, bool show);
@@ -220,7 +232,7 @@ private:
 	static HMONITOR GetTaskbarMonitor(Window taskbar);
 	static TaskbarType GetTaskbarType(Window taskbar);
 
-	TaskbarAppearance ApplyAdaptiveContrast(taskbar_iterator taskbar, TaskbarAppearance config) const;
+	TaskbarAppearance ApplyAdaptiveOpacity(taskbar_iterator taskbar, TaskbarAppearance config);
 
 	inline TaskbarAppearance WithPreview(txmp::TaskbarState state, const TaskbarAppearance &appearance) const
 	{
@@ -230,7 +242,7 @@ private:
 		{
 			result = { appearance.Accent, *preview, appearance.ShowPeek, appearance.ShowLine, appearance.BlurRadius, appearance.AdaptiveOpacity };
 		}
-		return ApplyAdaptiveContrast(taskbar, result);
+		return result;
 	}
 
 	inline static HMONITOR GetStartMenuMonitor() noexcept
@@ -268,10 +280,7 @@ private:
 public:
 	TaskbarAttributeWorker(ConfigManager &cfgManager, HINSTANCE hInstance, DynamicLoader &loader, const std::optional<std::filesystem::path> &storageFolder);
 
-	inline void ConfigurationChanged()
-	{
-		RefreshAllAttributes();
-	}
+	void ConfigurationChanged();
 
 	void ApplyColorPreview(txmp::TaskbarState state, Util::Color color)
 	{

--- a/TranslucentTB/taskbar/taskbarattributeworker.hpp
+++ b/TranslucentTB/taskbar/taskbarattributeworker.hpp
@@ -25,6 +25,7 @@
 #include "../windows/messagewindow.hpp"
 #include "undoc/user32.hpp"
 #include "undoc/uxtheme.hpp"
+#include "util/adaptiveopacity.hpp"
 #include "util/color.hpp"
 #include "util/null_terminated_string_view.hpp"
 #include "wilx.hpp"
@@ -62,11 +63,6 @@ private:
 		HMONITOR monitor;
 	};
 
-	struct AdaptiveOpacityState {
-		uint8_t Alpha;
-		std::chrono::steady_clock::time_point LastSample;
-	};
-
 	inline static constexpr UINT_PTR AdaptiveOpacityTimer = 1;
 	inline static constexpr UINT AdaptiveOpacityIntervalMs = 1000;
 
@@ -100,7 +96,7 @@ private:
 	Window m_ForegroundWindow;
 	TaskbarType m_TaskbarType;
 	std::unordered_map<HMONITOR, MonitorInfo> m_Taskbars;
-	std::unordered_map<HMONITOR, AdaptiveOpacityState> m_AdaptiveOpacityStates;
+	std::unordered_map<HMONITOR, Util::AdaptiveOpacity::OpacityState> m_AdaptiveOpacityStates;
 	std::unordered_set<Window> m_NormalTaskbars;
 	ConfigManager &m_ConfigManager;
 
@@ -191,6 +187,7 @@ private:
 	// Config
 	TaskbarAppearance SelectConfig(taskbar_iterator taskbar) const;
 	TaskbarAppearance GetConfig(taskbar_iterator taskbar);
+	void SampleAdaptiveOpacity();
 	void UpdateAdaptiveOpacityTimer();
 
 	// Attribute

--- a/TranslucentTB/taskbar/taskbarattributeworker.hpp
+++ b/TranslucentTB/taskbar/taskbarattributeworker.hpp
@@ -220,17 +220,17 @@ private:
 	static HMONITOR GetTaskbarMonitor(Window taskbar);
 	static TaskbarType GetTaskbarType(Window taskbar);
 
+	TaskbarAppearance ApplyAdaptiveContrast(taskbar_iterator taskbar, TaskbarAppearance config) const;
+
 	inline TaskbarAppearance WithPreview(txmp::TaskbarState state, const TaskbarAppearance &appearance) const
 	{
 		const auto &preview = m_ColorPreviews.at(static_cast<std::size_t>(state));
+		TaskbarAppearance result = appearance;
 		if (preview)
 		{
-			return { appearance.Accent, *preview, appearance.ShowPeek, appearance.ShowLine, appearance.BlurRadius };
+			result = { appearance.Accent, *preview, appearance.ShowPeek, appearance.ShowLine, appearance.BlurRadius, appearance.AdaptiveOpacity };
 		}
-		else
-		{
-			return appearance;
-		}
+		return ApplyAdaptiveContrast(taskbar, result);
 	}
 
 	inline static HMONITOR GetStartMenuMonitor() noexcept

--- a/TranslucentTB/taskbar/taskbarbackgroundsampler.cpp
+++ b/TranslucentTB/taskbar/taskbarbackgroundsampler.cpp
@@ -1,0 +1,42 @@
+#include "taskbarbackgroundsampler.hpp"
+
+#include <wingdi.h>
+#include <winuser.h>
+#include <wil/resource.h>
+
+std::optional<std::vector<Util::Color>> TaskbarBackgroundSampler::Sample(const RECT &taskbarRect, const RECT &monitorRect) noexcept
+{
+	const auto points = SamplePoints(taskbarRect, monitorRect);
+	if (!points)
+	{
+		return std::nullopt;
+	}
+
+	const HDC screenDc = GetDC(nullptr);
+	if (!screenDc)
+	{
+		return std::nullopt;
+	}
+	const auto releaseDc = wil::scope_exit([screenDc]
+	{
+		ReleaseDC(nullptr, screenDc);
+	});
+
+	std::vector<Util::Color> samples;
+	samples.reserve(points->size());
+	for (const auto point : *points)
+	{
+		const COLORREF color = GetPixel(screenDc, point.x, point.y);
+		if (color != CLR_INVALID)
+		{
+			samples.emplace_back(GetRValue(color), GetGValue(color), GetBValue(color));
+		}
+	}
+
+	if (samples.empty())
+	{
+		return std::nullopt;
+	}
+
+	return samples;
+}

--- a/TranslucentTB/taskbar/taskbarbackgroundsampler.hpp
+++ b/TranslucentTB/taskbar/taskbarbackgroundsampler.hpp
@@ -1,0 +1,83 @@
+#pragma once
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdlib>
+#include <optional>
+#include <vector>
+#include "arch.h"
+#include <windef.h>
+
+#include "util/color.hpp"
+
+class TaskbarBackgroundSampler
+{
+public:
+	static constexpr std::size_t SampleCount = 48;
+	static constexpr LONG StripOffset = 2;
+	using sample_points = std::array<POINT, SampleCount>;
+
+	static std::optional<sample_points> SamplePoints(const RECT &taskbarRect, const RECT &monitorRect) noexcept
+	{
+		const LONG taskbarWidth = taskbarRect.right - taskbarRect.left;
+		const LONG taskbarHeight = taskbarRect.bottom - taskbarRect.top;
+		const LONG monitorWidth = monitorRect.right - monitorRect.left;
+		const LONG monitorHeight = monitorRect.bottom - monitorRect.top;
+		if (taskbarWidth <= 0 || taskbarHeight <= 0 || monitorWidth <= 0 || monitorHeight <= 0)
+		{
+			return std::nullopt;
+		}
+
+		sample_points points;
+		if (taskbarWidth >= taskbarHeight)
+		{
+			const LONG first = std::max(taskbarRect.left, monitorRect.left);
+			const LONG last = std::min(taskbarRect.right, monitorRect.right) - 1;
+			if (first > last)
+			{
+				return std::nullopt;
+			}
+
+			const LONG topDistance = std::abs(taskbarRect.top - monitorRect.top);
+			const LONG bottomDistance = std::abs(monitorRect.bottom - taskbarRect.bottom);
+			const LONG sampleY = topDistance <= bottomDistance
+				? std::clamp(taskbarRect.bottom + StripOffset - 1, monitorRect.top, monitorRect.bottom - 1)
+				: std::clamp(taskbarRect.top - StripOffset, monitorRect.top, monitorRect.bottom - 1);
+
+			for (std::size_t index = 0; index < points.size(); ++index)
+			{
+				points[index] = {
+					first + static_cast<LONG>((last - first) * index / (points.size() - 1)),
+					sampleY
+				};
+			}
+		}
+		else
+		{
+			const LONG first = std::max(taskbarRect.top, monitorRect.top);
+			const LONG last = std::min(taskbarRect.bottom, monitorRect.bottom) - 1;
+			if (first > last)
+			{
+				return std::nullopt;
+			}
+
+			const LONG leftDistance = std::abs(taskbarRect.left - monitorRect.left);
+			const LONG rightDistance = std::abs(monitorRect.right - taskbarRect.right);
+			const LONG sampleX = leftDistance <= rightDistance
+				? std::clamp(taskbarRect.right + StripOffset - 1, monitorRect.left, monitorRect.right - 1)
+				: std::clamp(taskbarRect.left - StripOffset, monitorRect.left, monitorRect.right - 1);
+
+			for (std::size_t index = 0; index < points.size(); ++index)
+			{
+				points[index] = {
+					sampleX,
+					first + static_cast<LONG>((last - first) * index / (points.size() - 1))
+				};
+			}
+		}
+
+		return points;
+	}
+
+	static std::optional<std::vector<Util::Color>> Sample(const RECT &taskbarRect, const RECT &monitorRect) noexcept;
+};

--- a/Xaml/Models/Primitives/OptionalTaskbarAppearance.h
+++ b/Xaml/Models/Primitives/OptionalTaskbarAppearance.h
@@ -10,8 +10,8 @@ namespace winrt::TranslucentTB::Xaml::Models::Primitives::implementation
 	struct OptionalTaskbarAppearance : OptionalTaskbarAppearanceT<OptionalTaskbarAppearance, TaskbarAppearance>
 	{
 		OptionalTaskbarAppearance() noexcept = default;
-		OptionalTaskbarAppearance(bool enabled, AccentState accent, Windows::UI::Color color, bool showPeek, bool showLine, float blurRadius) noexcept :
-			base_type(accent, color, showPeek, showLine, blurRadius),
+		OptionalTaskbarAppearance(bool enabled, AccentState accent, Windows::UI::Color color, bool showPeek, bool showLine, float blurRadius, bool adaptiveOpacity) noexcept :
+			base_type(accent, color, showPeek, showLine, blurRadius, adaptiveOpacity),
 			m_Enabled(enabled)
 		{ }
 

--- a/Xaml/Models/Primitives/OptionalTaskbarAppearance.idl
+++ b/Xaml/Models/Primitives/OptionalTaskbarAppearance.idl
@@ -5,7 +5,7 @@ namespace TranslucentTB.Xaml.Models.Primitives
 	runtimeclass OptionalTaskbarAppearance : TaskbarAppearance
 	{
 		OptionalTaskbarAppearance();
-		OptionalTaskbarAppearance(Boolean enabled, AccentState accent, Windows.UI.Color color, Boolean showPeek, Boolean showLine, Single blurRadius);
+		OptionalTaskbarAppearance(Boolean enabled, AccentState accent, Windows.UI.Color color, Boolean showPeek, Boolean showLine, Single blurRadius, Boolean adaptiveOpacity);
 
 		[noexcept]
 		Boolean Enabled;

--- a/Xaml/Models/Primitives/TaskbarAppearance.h
+++ b/Xaml/Models/Primitives/TaskbarAppearance.h
@@ -9,18 +9,20 @@ namespace winrt::TranslucentTB::Xaml::Models::Primitives::implementation
 	struct TaskbarAppearance : TaskbarAppearanceT<TaskbarAppearance>
 	{
 		TaskbarAppearance() noexcept = default;
-		TaskbarAppearance(AccentState accent, Windows::UI::Color color, bool showPeek, bool showLine, float blurRadius) noexcept :
+		TaskbarAppearance(AccentState accent, Windows::UI::Color color, bool showPeek, bool showLine, float blurRadius, bool adaptiveOpacity) noexcept :
 			m_Accent(accent),
 			m_Color(color),
 			m_ShowPeek(showPeek),
 			m_ShowLine(showLine),
-			m_Radius(blurRadius)
+			m_Radius(blurRadius),
+			m_AdaptiveOpacity(adaptiveOpacity)
 		{ }
 
 		DECL_PROPERTY_FUNCS(AccentState, Accent, m_Accent);
 		DECL_PROPERTY_FUNCS(Windows::UI::Color, Color, m_Color);
 		DECL_PROPERTY_FUNCS(bool, ShowPeek, m_ShowPeek);
 		DECL_PROPERTY_FUNCS(bool, ShowLine, m_ShowLine);
+		DECL_PROPERTY_FUNCS(bool, AdaptiveOpacity, m_AdaptiveOpacity);
 		DECL_PROPERTY_FUNCS(float, BlurRadius, m_Radius);
 
 	private:
@@ -29,6 +31,7 @@ namespace winrt::TranslucentTB::Xaml::Models::Primitives::implementation
 		bool m_ShowPeek = true;
 		bool m_ShowLine = true;
 		float m_Radius = 9.0f;
+		bool m_AdaptiveOpacity = false;
 	};
 }
 

--- a/Xaml/Models/Primitives/TaskbarAppearance.idl
+++ b/Xaml/Models/Primitives/TaskbarAppearance.idl
@@ -5,7 +5,7 @@ namespace TranslucentTB.Xaml.Models.Primitives
 	unsealed runtimeclass TaskbarAppearance
 	{
 		TaskbarAppearance();
-		TaskbarAppearance(AccentState accent, Windows.UI.Color color, Boolean showPeek, Boolean showLine, Single blurRadius);
+		TaskbarAppearance(AccentState accent, Windows.UI.Color color, Boolean showPeek, Boolean showLine, Single blurRadius, Boolean adaptiveOpacity);
 
 		[noexcept]
 		AccentState Accent;
@@ -18,6 +18,9 @@ namespace TranslucentTB.Xaml.Models.Primitives
 
 		[noexcept]
 		Boolean ShowLine;
+
+		[noexcept]
+		Boolean AdaptiveOpacity;
 
 		[noexcept]
 		Single BlurRadius;

--- a/Xaml/Pages/TrayFlyoutPage.cpp
+++ b/Xaml/Pages/TrayFlyoutPage.cpp
@@ -65,6 +65,11 @@ namespace winrt::TranslucentTB::Xaml::Pages::implementation
 						toggleItem.IsChecked(appearance.ShowLine());
 						toggleItem.IsEnabled(enabled);
 					}
+					else if (stringTag == L"AdaptiveOpacity")
+					{
+						toggleItem.IsChecked(appearance.AdaptiveOpacity());
+						toggleItem.IsEnabled(enabled);
+					}
 				}
 				else if (tag.try_as<hstring>() == L"Color")
 				{
@@ -315,6 +320,10 @@ namespace winrt::TranslucentTB::Xaml::Pages::implementation
 				else if (tag.try_as<hstring>() == L"ShowLine")
 				{
 					appearance.ShowLine(toggleItem.IsChecked());
+				}
+				else if (tag.try_as<hstring>() == L"AdaptiveOpacity")
+				{
+					appearance.AdaptiveOpacity(toggleItem.IsChecked());
 				}
 			}
 		}

--- a/Xaml/Pages/TrayFlyoutPage.xaml
+++ b/Xaml/Pages/TrayFlyoutPage.xaml
@@ -25,6 +25,7 @@
                 </MenuFlyoutSubItem.Icon>
                 <ToggleMenuFlyoutItem Tag="ShowPeek" x:Uid="TrayFlyoutPage_PeekButton" Style="{StaticResource MergeIconsToggleMenuFlyoutItem}" Click="AppearanceClicked" />
                 <ToggleMenuFlyoutItem Tag="ShowLine" x:Uid="TrayFlyoutPage_LineButton" Style="{StaticResource MergeIconsToggleMenuFlyoutItem}" Click="AppearanceClicked" />
+                <ToggleMenuFlyoutItem Tag="AdaptiveOpacity" x:Uid="TrayFlyoutPage_AdaptiveOpacity" Style="{StaticResource MergeIconsToggleMenuFlyoutItem}" Click="AppearanceClicked" />
                 <MenuFlyoutItem Tag="Color" x:Uid="TrayFlyoutPage_AccentColor" Style="{StaticResource MergeIconsMenuFlyoutItem}" Click="ColorClicked">
                     <MenuFlyoutItem.Icon>
                         <FontIcon Glyph="&#xE790;" />

--- a/Xaml/Strings/en-US/Resources.resw
+++ b/Xaml/Strings/en-US/Resources.resw
@@ -245,6 +245,9 @@
   <data name="TrayFlyoutPage_PeekButton.Text" xml:space="preserve">
     <value>Show Desktop Peek Button</value>
   </data>
+  <data name="TrayFlyoutPage_AdaptiveOpacity.Text" xml:space="preserve">
+    <value>Adaptive Opacity</value>
+  </data>
   <data name="TrayFlyoutPage_SearchOpened.Text" xml:space="preserve">
     <value>Search opened</value>
     <comment>Also used to generate the title of color picker windows</comment>

--- a/settings.schema.json
+++ b/settings.schema.json
@@ -25,6 +25,9 @@
         "show_line": {
           "type": "boolean"
         },
+        "adaptive_opacity": {
+          "type": "boolean"
+        },
         "blur_radius": {
           "type": "number",
           "minimum": 0,


### PR DESCRIPTION
## Summary

- add an Adaptive opacity option to taskbar appearances and propagate it through JSON, native configuration, WinRT models, previews, and per-application rules
- sample 48 pixels from the content edge adjacent to each taskbar once per second while the option is active
- derive opacity from linear-sRGB luminance, bright-area coverage, and a 75th-percentile signal
- smooth opacity changes, rise faster than decay, and preserve the configured alpha as the minimum
- stop sampling when no current taskbar appearance uses adaptive opacity and fall back to the configured appearance if sampling fails

## Motivation

White taskbar text and icons can become unreadable when a transparent taskbar overlaps white or very bright content. This feature increases only the taskbar background opacity when bright content is detected, retaining the user's configured appearance on darker content.

The implementation intentionally uses sparse GDI pixel reads instead of continuous screen capture to keep runtime overhead close to normal TranslucentTB usage.

## Implementation notes

The original implementation hook could not compile because the preview helper referenced an undefined taskbar iterator. It also did not propagate the setting through the WinRT model, and rule-return paths bypassed the hook. This replacement centralizes adaptive processing after appearance selection so state appearances, previews, and rules follow the same path.

This supersedes #1337.

## Validation

- Debug x64 MSIX packaging build: 0 warnings, 0 errors
- Unit tests: 98 passed
- Added coverage for JSON/WinRT propagation, luminance and alpha behavior, smoothing, configured-alpha floor, bright-area detection, and taskbar sampling geometry on all four screen edges
- Verified the PR diff contains no internal planning documents or local dependency-setup files
